### PR TITLE
Implement go_router navigation shell

### DIFF
--- a/lib/features/habit/habit_detail_screen.dart
+++ b/lib/features/habit/habit_detail_screen.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../routing/route_paths.dart';
+
+class HabitDetailScreen extends StatelessWidget {
+  const HabitDetailScreen({super.key, required this.habitId});
+
+  final String habitId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Habit $habitId')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('Details for habit: $habitId'),
+            const Spacer(),
+            ElevatedButton(
+              onPressed: () {
+                context.go(RoutePaths.habitEditPath(habitId));
+              },
+              child: const Text('Edit Habit'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/habit/habit_edit_screen.dart
+++ b/lib/features/habit/habit_edit_screen.dart
@@ -17,6 +17,7 @@ class HabitEditScreen extends ConsumerStatefulWidget {
 class _HabitEditScreenState extends ConsumerState<HabitEditScreen> {
   late final TextEditingController _controller;
   bool _loading = true;
+  bool _draftCleared = false;
 
   @override
   void initState() {
@@ -38,9 +39,11 @@ class _HabitEditScreenState extends ConsumerState<HabitEditScreen> {
 
   @override
   void dispose() {
-    ref
-        .read(navStateStoreProvider)
-        .writeHabitEditDraft(habitId: widget.habitId, json: _controller.text);
+    if (!_draftCleared) {
+      ref
+          .read(navStateStoreProvider)
+          .writeHabitEditDraft(habitId: widget.habitId, json: _controller.text);
+    }
     _controller.dispose();
     super.dispose();
   }
@@ -65,6 +68,7 @@ class _HabitEditScreenState extends ConsumerState<HabitEditScreen> {
             const Spacer(),
             ElevatedButton(
               onPressed: () async {
+                _draftCleared = true;
                 await ref.read(navStateStoreProvider).clearHabitEditDraft(widget.habitId);
                 // TODO: Persist changes to backend.
                 if (!context.mounted) return;

--- a/lib/features/habit/habit_edit_screen.dart
+++ b/lib/features/habit/habit_edit_screen.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../routing/route_paths.dart';
+import '../../shared/services/nav_state_store.dart';
+
+class HabitEditScreen extends ConsumerStatefulWidget {
+  const HabitEditScreen({super.key, required this.habitId});
+
+  final String habitId;
+
+  @override
+  ConsumerState<HabitEditScreen> createState() => _HabitEditScreenState();
+}
+
+class _HabitEditScreenState extends ConsumerState<HabitEditScreen> {
+  late final TextEditingController _controller;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+    Future.microtask(() async {
+      final draft =
+          await ref.read(navStateStoreProvider).readHabitEditDraft(widget.habitId);
+      if (draft != null) {
+        _controller.text = draft;
+      } else {
+        _controller.text = 'Existing habit ${widget.habitId}';
+      }
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    ref
+        .read(navStateStoreProvider)
+        .writeHabitEditDraft(habitId: widget.habitId, json: _controller.text);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: Text('Edit ${widget.habitId}')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _controller,
+              decoration: const InputDecoration(labelText: 'Habit Name'),
+            ),
+            const Spacer(),
+            ElevatedButton(
+              onPressed: () async {
+                await ref.read(navStateStoreProvider).clearHabitEditDraft(widget.habitId);
+                // TODO: Persist changes to backend.
+                if (!context.mounted) return;
+                context.go(RoutePaths.habitDetailPath(widget.habitId));
+              },
+              child: const Text('Save Changes'),
+            ),
+            TextButton(
+              onPressed: () {
+                ref
+                    .read(navStateStoreProvider)
+                    .writeHabitEditDraft(
+                      habitId: widget.habitId,
+                      json: _controller.text,
+                    );
+                context.go(RoutePaths.today);
+              },
+              child: const Text('Save Draft & Exit'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/habit/habit_new_screen.dart
+++ b/lib/features/habit/habit_new_screen.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../routing/route_paths.dart';
+import '../../shared/services/nav_state_store.dart';
+
+class HabitNewScreen extends ConsumerStatefulWidget {
+  const HabitNewScreen({super.key});
+
+  @override
+  ConsumerState<HabitNewScreen> createState() => _HabitNewScreenState();
+}
+
+class _HabitNewScreenState extends ConsumerState<HabitNewScreen> {
+  late final TextEditingController _controller;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+    Future.microtask(() async {
+      final draft = await ref.read(navStateStoreProvider).readHabitNewDraft();
+      if (draft != null) {
+        _controller.text = draft;
+      }
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    ref.read(navStateStoreProvider).writeHabitNewDraft(_controller.text);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('New Habit')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _controller,
+              decoration: const InputDecoration(labelText: 'Habit Name'),
+            ),
+            const Spacer(),
+            ElevatedButton(
+              onPressed: () async {
+                await ref.read(navStateStoreProvider).clearHabitNewDraft();
+                // TODO: Save habit to backend and obtain an ID.
+                if (!context.mounted) return;
+                context.go(RoutePaths.habitDetailPath('new-habit'));
+              },
+              child: const Text('Create Habit'),
+            ),
+            TextButton(
+              onPressed: () {
+                ref
+                    .read(navStateStoreProvider)
+                    .writeHabitNewDraft(_controller.text);
+                context.go(RoutePaths.today);
+              },
+              child: const Text('Save Draft & Exit'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/habit/habit_new_screen.dart
+++ b/lib/features/habit/habit_new_screen.dart
@@ -15,6 +15,7 @@ class HabitNewScreen extends ConsumerStatefulWidget {
 class _HabitNewScreenState extends ConsumerState<HabitNewScreen> {
   late final TextEditingController _controller;
   bool _loading = true;
+  bool _draftCleared = false;
 
   @override
   void initState() {
@@ -33,7 +34,9 @@ class _HabitNewScreenState extends ConsumerState<HabitNewScreen> {
 
   @override
   void dispose() {
-    ref.read(navStateStoreProvider).writeHabitNewDraft(_controller.text);
+    if (!_draftCleared) {
+      ref.read(navStateStoreProvider).writeHabitNewDraft(_controller.text);
+    }
     _controller.dispose();
     super.dispose();
   }
@@ -58,6 +61,7 @@ class _HabitNewScreenState extends ConsumerState<HabitNewScreen> {
             const Spacer(),
             ElevatedButton(
               onPressed: () async {
+                _draftCleared = true;
                 await ref.read(navStateStoreProvider).clearHabitNewDraft();
                 // TODO: Save habit to backend and obtain an ID.
                 if (!context.mounted) return;

--- a/lib/features/insights/insights_detail_screen.dart
+++ b/lib/features/insights/insights_detail_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class InsightsDetailScreen extends StatelessWidget {
+  const InsightsDetailScreen({
+    super.key,
+    required this.metric,
+    required this.range,
+    this.habitId,
+  });
+
+  final String metric;
+  final String range;
+  final String? habitId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Insight Detail')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Metric: $metric'),
+            Text('Range: $range'),
+            if (habitId != null) Text('Habit: $habitId'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/insights/insights_home_screen.dart
+++ b/lib/features/insights/insights_home_screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../routing/route_paths.dart';
+
+class InsightsHomeScreen extends StatelessWidget {
+  const InsightsHomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Insights Home')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text('High level analytics overview.'),
+          const SizedBox(height: 12),
+          ElevatedButton(
+            onPressed: () => context.go(
+              RoutePaths.insightsDetailPath(metric: 'focus', range: '30d'),
+            ),
+            child: const Text('Open 30 Day Focus Insight'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../routing/route_paths.dart';
+import '../../shared/services/onboarding_service.dart';
+
+class OnboardingScreen extends ConsumerWidget {
+  const OnboardingScreen({super.key, this.next});
+
+  final String? next;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Welcome to Nudge')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              'Onboarding flow placeholder. Complete to continue.',
+            ),
+            const Spacer(),
+            ElevatedButton(
+              onPressed: () async {
+                await ref.read(onboardingServiceProvider).completeOnboarding();
+                final destination = next ?? RoutePaths.today;
+                if (!context.mounted) return;
+                context.go(destination);
+              },
+              child: const Text('Finish Onboarding'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/paywall/paywall_screen.dart
+++ b/lib/features/paywall/paywall_screen.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../routing/route_paths.dart';
+import '../../shared/services/entitlements_service.dart';
+
+class PaywallScreen extends ConsumerWidget {
+  const PaywallScreen({super.key, this.next});
+
+  final String? next;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Go Pro')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text('Unlock pro features by upgrading.'),
+            const Spacer(),
+            ElevatedButton(
+              onPressed: () async {
+                await ref.read(entitlementsServiceProvider).grantPro();
+                final destination = next ?? RoutePaths.today;
+                if (!context.mounted) return;
+                context.go(destination);
+              },
+              child: const Text('Upgrade Now'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,57 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-void main() {
-  runApp(const MyApp());
+import 'routing/app_router.dart';
+import 'routing/deep_link_handler.dart';
+import 'routing/route_paths.dart';
+import 'shared/services/nav_state_store.dart';
+import 'shared/utils/snackbar.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final navStateStore = NavStateStore();
+  final selectedTab = await navStateStore.readSelectedTab() ?? AppTab.today;
+  final tabLocations = await navStateStore.readTabTopLocations();
+  final initialConfig = InitialNavConfiguration(
+    selectedTab: selectedTab,
+    tabLocations: tabLocations,
+  );
+
+  runApp(
+    ProviderScope(
+      overrides: [
+        navStateStoreProvider.overrideWithValue(navStateStore),
+        initialNavConfigProvider.overrideWithValue(initialConfig),
+      ],
+      child: const NudgeApp(),
+    ),
+  );
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class NudgeApp extends ConsumerWidget {
+  const NudgeApp({super.key});
 
-  // This widget is the root of your application.
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(goRouterProvider);
+    return MaterialApp.router(
+      title: 'Nudge',
+      debugShowCheckedModeBanner: false,
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+        colorSchemeSeed: Colors.teal,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      scaffoldMessengerKey: scaffoldMessengerKey,
+      routerConfig: router,
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
-    );
-  }
+/// Example hook for handling an external notification or widget intent.
+Future<void> handleExternalIntent(Uri uri, WidgetRef ref) async {
+  final intent = DeepLinkHandler.parse(uri);
+  final router = ref.read(goRouterProvider);
+  final snackBar = ref.read(snackBarServiceProvider);
+  await NavIntentExecutor.execute(intent, router, snackBarService: snackBar);
 }

--- a/lib/routing/app_router.dart
+++ b/lib/routing/app_router.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../features/habit/habit_detail_screen.dart';
+import '../features/habit/habit_edit_screen.dart';
+import '../features/habit/habit_new_screen.dart';
+import '../features/insights/insights_detail_screen.dart';
+import '../features/onboarding/onboarding_screen.dart';
+import '../features/paywall/paywall_screen.dart';
+import '../routing/router_keys.dart';
+import '../shell/app_shell.dart';
+import '../shell/tabs/insights_tab.dart';
+import '../shell/tabs/plan_tab.dart';
+import '../shell/tabs/settings_tab.dart';
+import '../shell/tabs/today_tab.dart';
+import '../shared/services/entitlements_service.dart';
+import '../shared/services/nav_state_store.dart';
+import '../shared/services/onboarding_service.dart';
+import '../shared/utils/snackbar.dart';
+import 'navigation_observer.dart';
+import 'route_guards.dart';
+import 'route_paths.dart';
+
+class InitialNavConfiguration {
+  InitialNavConfiguration({
+    required this.selectedTab,
+    required this.tabLocations,
+  });
+
+  final AppTab selectedTab;
+  final Map<AppTab, String> tabLocations;
+}
+
+final initialNavConfigProvider = Provider<InitialNavConfiguration>((ref) {
+  throw UnimplementedError('InitialNavConfiguration must be overridden.');
+});
+
+final appNavigationObserverProvider = Provider<AppNavigationObserver>((ref) {
+  return AppNavigationObserver(
+    onRouteEnter: (routeName, params) {
+      // TODO: wire analytics event.
+    },
+    onRouteRedirect: (from, to, reason) {
+      // TODO: send redirect telemetry.
+    },
+    onTabSwitch: (from, to) {
+      // TODO: capture tab switch analytics.
+    },
+  );
+});
+
+String _defaultTabLocation(AppTab tab) {
+  switch (tab) {
+    case AppTab.today:
+      return RoutePaths.today;
+    case AppTab.plan:
+      return RoutePaths.plan;
+    case AppTab.insights:
+      return RoutePaths.insights;
+    case AppTab.settings:
+      return RoutePaths.settings;
+  }
+}
+
+final goRouterProvider = Provider<GoRouter>((ref) {
+  final onboardingService = ref.watch(onboardingServiceProvider);
+  final entitlementsService = ref.watch(entitlementsServiceProvider);
+  final navStateStore = ref.watch(navStateStoreProvider);
+  final snackBarService = ref.watch(snackBarServiceProvider);
+  final observer = ref.watch(appNavigationObserverProvider);
+  final initialConfig = ref.watch(initialNavConfigProvider);
+
+  String initialLocationFor(AppTab tab) {
+    return initialConfig.tabLocations[tab] ?? _defaultTabLocation(tab);
+  }
+
+  return GoRouter(
+    navigatorKey: rootNavigatorKey,
+    initialLocation: initialLocationFor(initialConfig.selectedTab),
+    observers: [observer],
+    debugLogDiagnostics: false,
+    restorationScopeId: 'nudge-router',
+    refreshListenable:
+        Listenable.merge([onboardingService, entitlementsService]),
+    redirect: (context, state) async {
+      final attempted = state.uri.toString();
+      final onboardingResult = await onboardingRedirect(
+        onboardingService: onboardingService,
+        attemptedLocation: attempted,
+      );
+      if (onboardingResult != null) {
+        observer.reportRedirect(
+          from: attempted,
+          to: onboardingResult,
+          reason: 'onboarding',
+        );
+        return onboardingResult;
+      }
+      return null;
+    },
+    routes: [
+      StatefulShellRoute.indexedStack(
+        builder: (context, state, navigationShell) {
+          final tab = initialConfig.selectedTab;
+          return AppShell(
+            navigationShell: navigationShell,
+            observer: observer,
+            initialTab: tab,
+          );
+        },
+        branches: [
+          StatefulShellBranch(
+            navigatorKey: todayNavigatorKey,
+            initialLocation: initialLocationFor(AppTab.today),
+            routes: [
+              GoRoute(
+                path: RoutePaths.today,
+                name: RoutePaths.todayName,
+                builder: (context, state) {
+                  navStateStore.writeTabTopLocation(
+                    tab: AppTab.today,
+                    location: state.uri.toString(),
+                  );
+                  return const TodayTabScreen();
+                },
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            navigatorKey: planNavigatorKey,
+            initialLocation: initialLocationFor(AppTab.plan),
+            routes: [
+              GoRoute(
+                path: RoutePaths.plan,
+                name: RoutePaths.planName,
+                builder: (context, state) {
+                  navStateStore.writeTabTopLocation(
+                    tab: AppTab.plan,
+                    location: state.uri.toString(),
+                  );
+                  return const PlanTabScreen();
+                },
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            navigatorKey: insightsNavigatorKey,
+            initialLocation: initialLocationFor(AppTab.insights),
+            routes: [
+              GoRoute(
+                path: RoutePaths.insights,
+                name: RoutePaths.insightsName,
+                builder: (context, state) {
+                  navStateStore.writeTabTopLocation(
+                    tab: AppTab.insights,
+                    location: state.uri.toString(),
+                  );
+                  return const InsightsTabScreen();
+                },
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            navigatorKey: settingsNavigatorKey,
+            initialLocation: initialLocationFor(AppTab.settings),
+            routes: [
+              GoRoute(
+                path: RoutePaths.settings,
+                name: RoutePaths.settingsName,
+                builder: (context, state) {
+                  navStateStore.writeTabTopLocation(
+                    tab: AppTab.settings,
+                    location: state.uri.toString(),
+                  );
+                  return const SettingsTabScreen();
+                },
+              ),
+            ],
+          ),
+        ],
+      ),
+      GoRoute(
+        parentNavigatorKey: rootNavigatorKey,
+        path: RoutePaths.onboarding,
+        name: RoutePaths.onboardingName,
+        builder: (context, state) {
+          return OnboardingScreen(next: state.uri.queryParameters['next']);
+        },
+      ),
+      GoRoute(
+        parentNavigatorKey: rootNavigatorKey,
+        path: RoutePaths.habitNew,
+        name: RoutePaths.habitNewName,
+        builder: (context, state) => const HabitNewScreen(),
+      ),
+      GoRoute(
+        parentNavigatorKey: rootNavigatorKey,
+        path: RoutePaths.habitDetail,
+        name: RoutePaths.habitDetailName,
+        redirect: (context, state) {
+          final habitId = state.pathParameters['id'];
+          if (habitId == null || habitId.isEmpty) {
+            snackBarService.showMessage('Habit not found. Returning to Today.');
+            return RoutePaths.today;
+          }
+          return null;
+        },
+        builder: (context, state) {
+          final habitId = state.pathParameters['id']!;
+          return HabitDetailScreen(habitId: habitId);
+        },
+      ),
+      GoRoute(
+        parentNavigatorKey: rootNavigatorKey,
+        path: RoutePaths.habitEdit,
+        name: RoutePaths.habitEditName,
+        redirect: (context, state) async {
+          final habitId = state.pathParameters['id'];
+          if (habitId == null || habitId.isEmpty) {
+            snackBarService.showMessage('Habit not found. Returning to Today.');
+            return RoutePaths.today;
+          }
+          final attempted = state.uri.toString();
+          final proResult = await proRedirect(
+            entitlementsService: entitlementsService,
+            attemptedLocation: attempted,
+          );
+          if (proResult != null) {
+            observer.reportRedirect(
+              from: attempted,
+              to: proResult,
+              reason: 'pro-gate',
+            );
+            return proResult;
+          }
+          return null;
+        },
+        builder: (context, state) {
+          final habitId = state.pathParameters['id']!;
+          return HabitEditScreen(habitId: habitId);
+        },
+      ),
+      GoRoute(
+        parentNavigatorKey: rootNavigatorKey,
+        path: RoutePaths.insightsDetail,
+        name: RoutePaths.insightsDetailName,
+        redirect: (context, state) async {
+          final metric = state.uri.queryParameters['metric'];
+          final range = state.uri.queryParameters['range'];
+          if (metric == null || range == null) {
+            snackBarService.showMessage('Insight unavailable. Showing Today.');
+            return RoutePaths.today;
+          }
+          final attempted = state.uri.toString();
+          final proResult = await proRedirect(
+            entitlementsService: entitlementsService,
+            attemptedLocation: attempted,
+          );
+          if (proResult != null) {
+            observer.reportRedirect(
+              from: attempted,
+              to: proResult,
+              reason: 'pro-gate',
+            );
+            return proResult;
+          }
+          return null;
+        },
+        builder: (context, state) {
+          final metric = state.uri.queryParameters['metric']!;
+          final range = state.uri.queryParameters['range']!;
+          final habitId = state.uri.queryParameters['habitId'];
+          return InsightsDetailScreen(
+            metric: metric,
+            range: range,
+            habitId: habitId,
+          );
+        },
+      ),
+      GoRoute(
+        parentNavigatorKey: rootNavigatorKey,
+        path: RoutePaths.paywall,
+        name: RoutePaths.paywallName,
+        builder: (context, state) {
+          return PaywallScreen(next: state.uri.queryParameters['next']);
+        },
+      ),
+    ],
+  );
+});

--- a/lib/routing/deep_link_handler.dart
+++ b/lib/routing/deep_link_handler.dart
@@ -1,0 +1,99 @@
+import 'package:go_router/go_router.dart';
+
+import '../shared/models/nav_intents.dart';
+import '../shared/utils/snackbar.dart';
+import 'route_paths.dart';
+
+/// Parses incoming URIs into strongly typed [NavIntent]s.
+class DeepLinkHandler {
+  static const _scheme = 'nudge';
+
+  static NavIntent parse(Uri? uri) {
+    if (uri == null) {
+      return const UnknownIntent();
+    }
+
+    if (uri.scheme == _scheme) {
+      return _parseAppScheme(uri);
+    }
+
+    // Allow direct HTTP(S) fallbacks by parsing the path segments.
+    if (uri.scheme == 'https' || uri.scheme == 'http') {
+      return _parsePathSegments(uri.pathSegments, uri.queryParameters);
+    }
+
+    return const UnknownIntent();
+  }
+
+  static NavIntent _parseAppScheme(Uri uri) {
+    final segments = <String>[];
+    if (uri.host.isNotEmpty) {
+      segments.add(uri.host);
+    }
+    segments.addAll(uri.pathSegments);
+    return _parsePathSegments(segments, uri.queryParameters);
+  }
+
+  static NavIntent _parsePathSegments(
+    List<String> segments,
+    Map<String, String> queryParams,
+  ) {
+    if (segments.isEmpty) {
+      return const UnknownIntent();
+    }
+
+    final first = segments.first;
+    switch (first) {
+      case 'habit':
+        if (segments.length >= 2 && segments[1].isNotEmpty) {
+          return OpenHabitIntent(segments[1]);
+        }
+        return const OpenTodayIntent();
+      case 'paywall':
+        final next = queryParams['next'];
+        return OpenPaywallIntent(next);
+      case 'today':
+        return const OpenTodayIntent();
+      case 'complete':
+        if (segments.length >= 2 && segments[1].isNotEmpty) {
+          return PerformCompleteIntent(segments[1]);
+        }
+        break;
+    }
+
+    return const UnknownIntent();
+  }
+}
+
+/// Executes navigation intents using the global [GoRouter] instance.
+class NavIntentExecutor {
+  static Future<void> execute(
+    NavIntent intent,
+    GoRouter router, {
+    required SnackBarService snackBarService,
+    Future<void> Function(String habitId)? onPerformCompletion,
+  }) async {
+    switch (intent) {
+      case OpenHabitIntent(:final habitId):
+        router.go(RoutePaths.habitDetailPath(habitId));
+        return;
+      case OpenPaywallIntent(:final nextLocation):
+        router.go(RoutePaths.paywallPath(next: nextLocation));
+        return;
+      case OpenTodayIntent():
+        router.go(RoutePaths.today);
+        return;
+      case PerformCompleteIntent(:final habitId):
+        if (onPerformCompletion != null) {
+          await onPerformCompletion(habitId);
+        }
+        // In a real app we would check visibility; assume visible for now.
+        snackBarService.showMessage('Marked habit $habitId complete');
+        return;
+      case UnknownIntent():
+        snackBarService.showMessage('Opening Today');
+        router.go(RoutePaths.today);
+        return;
+    }
+  }
+}

--- a/lib/routing/navigation_observer.dart
+++ b/lib/routing/navigation_observer.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/widgets.dart';
+
+import '../routing/route_paths.dart';
+
+typedef RouteEnterCallback = void Function(
+  String? routeName,
+  Map<String, String> params,
+);
+typedef RouteRedirectCallback = void Function(
+  String from,
+  String to,
+  String reason,
+);
+typedef TabSwitchCallback = void Function(AppTab from, AppTab to);
+
+/// Lightweight observer for navigation telemetry. Hooks into go_router's
+/// observer list and shell tab switching to notify analytics or debugging tools.
+class AppNavigationObserver extends NavigatorObserver {
+  AppNavigationObserver({
+    this.onRouteEnter,
+    this.onRouteRedirect,
+    this.onTabSwitch,
+  });
+
+  final RouteEnterCallback? onRouteEnter;
+  final RouteRedirectCallback? onRouteRedirect;
+  final TabSwitchCallback? onTabSwitch;
+
+  void reportRedirect({
+    required String from,
+    required String to,
+    required String reason,
+  }) {
+    onRouteRedirect?.call(from, to, reason);
+  }
+
+  void reportTabSwitch({
+    required AppTab from,
+    required AppTab to,
+  }) {
+    onTabSwitch?.call(from, to);
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    final settings = route.settings;
+    onRouteEnter?.call(settings.name, settings.arguments is Map<String, String>
+        ? settings.arguments! as Map<String, String>
+        : const {});
+  }
+}

--- a/lib/routing/route_guards.dart
+++ b/lib/routing/route_guards.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import '../shared/services/entitlements_service.dart';
+import '../shared/services/onboarding_service.dart';
+import 'route_paths.dart';
+
+/// Determines whether navigation should redirect to onboarding based on the
+/// onboarding completion state.
+Future<String?> onboardingRedirect({
+  required OnboardingService onboardingService,
+  required String attemptedLocation,
+}) async {
+  final isComplete = await onboardingService.isComplete();
+  if (isComplete) {
+    return null;
+  }
+
+  final onboardingBase = RoutePaths.onboarding;
+  if (attemptedLocation.startsWith(onboardingBase)) {
+    // Already heading to onboarding; allow it to proceed.
+    return null;
+  }
+
+  final encoded = Uri.encodeComponent(attemptedLocation);
+  return '$onboardingBase?next=$encoded';
+}
+
+/// Determines whether navigation should redirect to the paywall when the user
+/// lacks the required entitlement to open a pro-only destination.
+Future<String?> proRedirect({
+  required EntitlementsService entitlementsService,
+  required String attemptedLocation,
+}) async {
+  final isPro = await entitlementsService.isPro();
+  if (isPro) {
+    return null;
+  }
+
+  final paywallBase = RoutePaths.paywall;
+  if (attemptedLocation.startsWith(paywallBase)) {
+    // Already moving toward the paywall; avoid redirect loops.
+    return null;
+  }
+
+  final encoded = Uri.encodeComponent(attemptedLocation);
+  return '$paywallBase?next=$encoded';
+}

--- a/lib/routing/route_paths.dart
+++ b/lib/routing/route_paths.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/foundation.dart';
+
+/// Centralized definitions of route names and helpers for building locations.
+/// Keeping the strings in one place reduces typos and keeps deep link parsing
+/// consistent with navigation helpers.
+@immutable
+class RoutePaths {
+  const RoutePaths._();
+
+  // Shell tabs
+  static const today = '/today';
+  static const plan = '/plan';
+  static const insights = '/insights';
+  static const settings = '/settings';
+
+  // Standalone flows
+  static const onboarding = '/onboarding';
+  static const habitNew = '/habit/new';
+  static const habitDetail = '/habit/:id';
+  static const habitEdit = '/habit/:id/edit';
+  static const insightsDetail = '/insights/detail';
+  static const paywall = '/paywall';
+
+  // Route names used by go_router for analytics/telemetry.
+  static const shell = 'app-shell';
+  static const todayName = 'today';
+  static const planName = 'plan';
+  static const insightsName = 'insights';
+  static const settingsName = 'settings';
+  static const onboardingName = 'onboarding';
+  static const habitNewName = 'habit-new';
+  static const habitDetailName = 'habit-detail';
+  static const habitEditName = 'habit-edit';
+  static const insightsDetailName = 'insights-detail';
+  static const paywallName = 'paywall';
+
+  /// Location helper for habit detail.
+  static String habitDetailPath(String habitId) => '/habit/$habitId';
+
+  /// Location helper for habit edit.
+  static String habitEditPath(String habitId) => '/habit/$habitId/edit';
+
+  /// Location helper for onboarding with an optional next destination.
+  static String onboardingPath({String? next}) {
+    if (next == null || next.isEmpty) {
+      return onboarding;
+    }
+    return '$onboarding?next=${Uri.encodeComponent(next)}';
+  }
+
+  /// Location helper for the paywall with an optional continuation target.
+  static String paywallPath({String? next}) {
+    if (next == null || next.isEmpty) {
+      return paywall;
+    }
+    return '$paywall?next=${Uri.encodeComponent(next)}';
+  }
+
+  /// Location helper for the insights detail screen with optional filters.
+  static String insightsDetailPath({
+    required String metric,
+    required String range,
+    String? habitId,
+  }) {
+    final params = <String, String>{
+      'metric': metric,
+      'range': range,
+      if (habitId != null) 'habitId': habitId,
+    };
+    final query = params.entries
+        .map((entry) => '${entry.key}=${Uri.encodeComponent(entry.value)}')
+        .join('&');
+    return '$insightsDetail?$query';
+  }
+}
+
+/// Indexes for the four tabs surfaced in the shell scaffold. Using an enum
+/// provides type safety when reading/writing the persisted tab state.
+enum AppTab { today, plan, insights, settings }
+
+extension AppTabExtension on AppTab {
+  int get index {
+    switch (this) {
+      case AppTab.today:
+        return 0;
+      case AppTab.plan:
+        return 1;
+      case AppTab.insights:
+        return 2;
+      case AppTab.settings:
+        return 3;
+    }
+  }
+
+  static AppTab fromIndex(int index) {
+    if (index < 0 || index >= AppTab.values.length) {
+      return AppTab.today;
+    }
+    return AppTab.values[index];
+  }
+}

--- a/lib/routing/router_keys.dart
+++ b/lib/routing/router_keys.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+final rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'root');
+final todayNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'today');
+final planNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'plan');
+final insightsNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'insights');
+final settingsNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'settings');

--- a/lib/shared/models/nav_intents.dart
+++ b/lib/shared/models/nav_intents.dart
@@ -1,0 +1,49 @@
+import 'package:equatable/equatable.dart';
+
+/// Represents an external navigation request parsed from deep links or
+/// notification payloads. Additional intent types should extend this sealed
+/// hierarchy.
+sealed class NavIntent extends Equatable {
+  const NavIntent();
+}
+
+class OpenHabitIntent extends NavIntent {
+  const OpenHabitIntent(this.habitId);
+
+  final String habitId;
+
+  @override
+  List<Object?> get props => [habitId];
+}
+
+class OpenPaywallIntent extends NavIntent {
+  const OpenPaywallIntent(this.nextLocation);
+
+  final String? nextLocation;
+
+  @override
+  List<Object?> get props => [nextLocation];
+}
+
+class OpenTodayIntent extends NavIntent {
+  const OpenTodayIntent();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+class PerformCompleteIntent extends NavIntent {
+  const PerformCompleteIntent(this.habitId);
+
+  final String habitId;
+
+  @override
+  List<Object?> get props => [habitId];
+}
+
+class UnknownIntent extends NavIntent {
+  const UnknownIntent();
+
+  @override
+  List<Object?> get props => const [];
+}

--- a/lib/shared/services/entitlements_service.dart
+++ b/lib/shared/services/entitlements_service.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Service that represents whether the current user has access to pro
+/// functionality. The implementation would typically bridge to a purchases SDK
+/// or server-side entitlement check.
+class EntitlementsService extends ChangeNotifier {
+  bool _isPro = false;
+
+  bool get isProSync => _isPro;
+
+  Future<bool> isPro() async {
+    return _isPro;
+  }
+
+  Future<void> grantPro() async {
+    _isPro = true;
+    notifyListeners();
+  }
+
+  Future<void> revokePro() async {
+    _isPro = false;
+    notifyListeners();
+  }
+}
+
+final entitlementsServiceProvider = ChangeNotifierProvider<EntitlementsService>((ref) {
+  // TODO: bridge to real purchase flow implementation.
+  return EntitlementsService();
+});

--- a/lib/shared/services/nav_state_store.dart
+++ b/lib/shared/services/nav_state_store.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../routing/route_paths.dart';
+
+/// Simple in-memory navigation state store used to model state restoration.
+///
+/// Replace with a persistence-backed implementation (e.g. `SharedPreferences`)
+/// when wiring to production. The async APIs are intentionally retained so the
+/// swap remains seamless.
+class NavStateStore {
+  AppTab? _selectedTab;
+  final Map<AppTab, String> _tabTopLocations = {};
+  String? _habitDraft;
+  final Map<String, String> _habitEditDrafts = {};
+
+  Future<void> writeSelectedTab(AppTab tab) async {
+    _selectedTab = tab;
+  }
+
+  Future<AppTab?> readSelectedTab() async {
+    return _selectedTab;
+  }
+
+  Future<void> writeTabTopLocation({
+    required AppTab tab,
+    required String location,
+  }) async {
+    _tabTopLocations[tab] = location;
+  }
+
+  Future<Map<AppTab, String>> readTabTopLocations() async {
+    return Map<AppTab, String>.from(_tabTopLocations);
+  }
+
+  Future<void> writeHabitNewDraft(String json) async {
+    _habitDraft = json;
+  }
+
+  Future<String?> readHabitNewDraft() async {
+    return _habitDraft;
+  }
+
+  Future<void> clearHabitNewDraft() async {
+    _habitDraft = null;
+  }
+
+  Future<void> writeHabitEditDraft({
+    required String habitId,
+    required String json,
+  }) async {
+    _habitEditDrafts[habitId] = json;
+  }
+
+  Future<String?> readHabitEditDraft(String habitId) async {
+    return _habitEditDrafts[habitId];
+  }
+
+  Future<void> clearHabitEditDraft(String habitId) async {
+    _habitEditDrafts.remove(habitId);
+  }
+}
+
+final navStateStoreProvider = Provider<NavStateStore>((ref) {
+  // TODO: swap to persistence-backed store.
+  return NavStateStore();
+});

--- a/lib/shared/services/onboarding_service.dart
+++ b/lib/shared/services/onboarding_service.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Service responsible for tracking onboarding completion status.
+///
+/// In production this would delegate to persistent storage. For now we keep the
+/// completion flag in memory and expose async APIs that mirror an eventual
+/// implementation.
+class OnboardingService extends ChangeNotifier {
+  bool _isComplete = false;
+
+  bool get isCompleteSync => _isComplete;
+
+  Future<bool> isComplete() async {
+    return _isComplete;
+  }
+
+  Future<void> completeOnboarding() async {
+    _isComplete = true;
+    notifyListeners();
+  }
+
+  /// Resets onboarding completion. Useful for manual testing.
+  Future<void> reset() async {
+    _isComplete = false;
+    notifyListeners();
+  }
+}
+
+final onboardingServiceProvider = ChangeNotifierProvider<OnboardingService>((ref) {
+  // TODO: wire to persistent storage implementation.
+  return OnboardingService();
+});

--- a/lib/shared/utils/snackbar.dart
+++ b/lib/shared/utils/snackbar.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Global key used to display snack bars from anywhere in the app.
+final scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
+
+/// Simplistic snack bar service to surface one-shot messages. Stubbing the
+/// service allows tests to inject a fake implementation.
+class SnackBarService {
+  SnackBarService(this._messengerKey);
+
+  final GlobalKey<ScaffoldMessengerState> _messengerKey;
+
+  void showMessage(String message) {
+    final messenger = _messengerKey.currentState;
+    if (messenger == null) {
+      return;
+    }
+
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(SnackBar(content: Text(message)));
+  }
+}
+
+final snackBarServiceProvider = Provider<SnackBarService>((ref) {
+  // TODO: allow injecting mock messenger for widget tests.
+  return SnackBarService(scaffoldMessengerKey);
+});

--- a/lib/shared/widgets/global_banner.dart
+++ b/lib/shared/widgets/global_banner.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Controller used to show or hide a global banner. The implementation is a
+/// placeholder for future travel mode functionality.
+class GlobalBannerController extends ChangeNotifier {
+  bool _isVisible = false;
+  String? _message;
+
+  bool get isVisible => _isVisible;
+  String? get message => _message;
+
+  void show(String message) {
+    _isVisible = true;
+    _message = message;
+    notifyListeners();
+  }
+
+  void hide() {
+    _isVisible = false;
+    _message = null;
+    notifyListeners();
+  }
+}
+
+final globalBannerControllerProvider =
+    ChangeNotifierProvider<GlobalBannerController>((ref) {
+  return GlobalBannerController();
+});
+
+/// Hosts the banner at the top of the app without affecting navigator state.
+class GlobalBannerHost extends ConsumerWidget {
+  const GlobalBannerHost({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.watch(globalBannerControllerProvider);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (controller.isVisible)
+          Material(
+            color: Colors.orange.shade200,
+            child: SizedBox(
+              width: double.infinity,
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Text(
+                  controller.message ?? 'Travel mode active',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+          ),
+        Expanded(child: child),
+      ],
+    );
+  }
+}

--- a/lib/shell/app_shell.dart
+++ b/lib/shell/app_shell.dart
@@ -1,0 +1,151 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../routing/navigation_observer.dart';
+import '../routing/route_paths.dart';
+import '../routing/router_keys.dart';
+import '../shared/services/nav_state_store.dart';
+import '../shared/widgets/global_banner.dart';
+
+class AppShell extends ConsumerStatefulWidget {
+  const AppShell({
+    super.key,
+    required this.navigationShell,
+    required this.observer,
+    required this.initialTab,
+  });
+
+  final StatefulNavigationShell navigationShell;
+  final AppNavigationObserver observer;
+  final AppTab initialTab;
+
+  @override
+  ConsumerState<AppShell> createState() => _AppShellState();
+}
+
+class _AppShellState extends ConsumerState<AppShell> {
+  late int _currentIndex;
+
+  AppTab get _currentTab => AppTabExtension.fromIndex(_currentIndex);
+
+  @override
+  void initState() {
+    super.initState();
+    _currentIndex = widget.initialTab.index;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _persistTabState(_currentTab);
+    });
+  }
+
+  Future<bool> _onWillPop() async {
+    final branchNavigator = _navigatorForTab(_currentTab).currentState;
+    if (branchNavigator != null && branchNavigator.canPop()) {
+      branchNavigator.pop();
+      return false;
+    }
+
+    final router = GoRouter.of(context);
+    if (router.canPop()) {
+      router.pop();
+      return false;
+    }
+
+    if (Platform.isAndroid) {
+      await SystemNavigator.pop();
+      return false;
+    }
+
+    return true;
+  }
+
+  void _onTabSelected(int index) {
+    if (index == _currentIndex) {
+      widget.navigationShell.goBranch(index, initialLocation: true);
+      return;
+    }
+    final previous = _currentTab;
+    final next = AppTabExtension.fromIndex(index);
+    _persistTabState(previous);
+    widget.navigationShell.goBranch(index);
+    widget.observer.reportTabSwitch(from: previous, to: next);
+    setState(() => _currentIndex = index);
+    _persistTabState(next);
+  }
+
+  void _persistTabState(AppTab tab) {
+    ref.read(navStateStoreProvider).writeSelectedTab(tab);
+    final router = GoRouter.of(context);
+    final location =
+        router.routeInformationProvider.value.uri.toString();
+    ref.read(navStateStoreProvider).writeTabTopLocation(
+          tab: tab,
+          location: location,
+        );
+  }
+
+  GlobalKey<NavigatorState> _navigatorForTab(AppTab tab) {
+    if (tab == AppTab.today) {
+      return todayNavigatorKey;
+    }
+    if (tab == AppTab.plan) {
+      return planNavigatorKey;
+    }
+    if (tab == AppTab.insights) {
+      return insightsNavigatorKey;
+    }
+    return settingsNavigatorKey;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final navigationShell = widget.navigationShell;
+    return GlobalBannerHost(
+      child: PopScope(
+        canPop: false,
+        onPopInvokedWithResult: (didPop, result) async {
+          if (didPop) {
+            return;
+          }
+          final shouldPop = await _onWillPop();
+          if (!shouldPop) {
+            return;
+          }
+          if (!context.mounted) {
+            return;
+          }
+          Navigator.of(context).maybePop(result);
+        },
+        child: Scaffold(
+          body: navigationShell,
+          bottomNavigationBar: BottomNavigationBar(
+            currentIndex: _currentIndex,
+            onTap: _onTabSelected,
+            type: BottomNavigationBarType.fixed,
+            items: const [
+              BottomNavigationBarItem(
+                icon: Icon(Icons.today),
+                label: 'Today',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.calendar_month),
+                label: 'Plan',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.insights),
+                label: 'Insights',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.settings),
+                label: 'Settings',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shell/tabs/insights_tab.dart
+++ b/lib/shell/tabs/insights_tab.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../routing/route_paths.dart';
+
+class InsightsTabScreen extends StatelessWidget {
+  const InsightsTabScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Insights')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text('Insights and analytics appear here.'),
+          const SizedBox(height: 12),
+          ElevatedButton(
+            onPressed: () => context.go(
+              RoutePaths.insightsDetailPath(metric: 'streak', range: '7d'),
+            ),
+            child: const Text('Open Weekly Streak Insight'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shell/tabs/plan_tab.dart
+++ b/lib/shell/tabs/plan_tab.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../routing/route_paths.dart';
+
+class PlanTabScreen extends StatelessWidget {
+  const PlanTabScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Plan')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text('Plan upcoming routines.'),
+          const SizedBox(height: 12),
+          ElevatedButton(
+            onPressed: () => context.go(RoutePaths.habitNew),
+            child: const Text('Add Planned Habit'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shell/tabs/settings_tab.dart
+++ b/lib/shell/tabs/settings_tab.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../routing/route_paths.dart';
+import '../../shared/services/entitlements_service.dart';
+import '../../shared/services/onboarding_service.dart';
+
+class SettingsTabScreen extends ConsumerWidget {
+  const SettingsTabScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final onboarding = ref.watch(onboardingServiceProvider);
+    final entitlements = ref.watch(entitlementsServiceProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          SwitchListTile(
+            title: const Text('Onboarding Complete'),
+            value: onboarding.isCompleteSync,
+            onChanged: (value) async {
+              if (value) {
+                await onboarding.completeOnboarding();
+              } else {
+                await onboarding.reset();
+              }
+            },
+          ),
+          SwitchListTile(
+            title: const Text('Pro Access'),
+            value: entitlements.isProSync,
+            onChanged: (value) async {
+              if (value) {
+                await entitlements.grantPro();
+              } else {
+                await entitlements.revokePro();
+              }
+            },
+          ),
+          const Divider(),
+          TextButton(
+            onPressed: () {
+              // Demonstrates opening the paywall manually.
+              context.go(RoutePaths.paywall);
+            },
+            child: const Text('View Paywall'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shell/tabs/today_tab.dart
+++ b/lib/shell/tabs/today_tab.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../routing/route_paths.dart';
+
+class TodayTabScreen extends StatelessWidget {
+  const TodayTabScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Today')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text('Today overview goes here.'),
+          const SizedBox(height: 12),
+          ElevatedButton(
+            onPressed: () => context.go(RoutePaths.habitNew),
+            child: const Text('Create Habit'),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () => context.go(RoutePaths.habitDetailPath('demo')),
+            child: const Text('Open Sample Habit'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,9 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  go_router: ^14.2.1
+  flutter_riverpod: ^2.5.1
+  equatable: ^2.0.5
 
 dev_dependencies:
   flutter_test:

--- a/test/acceptance_plan.md
+++ b/test/acceptance_plan.md
@@ -1,0 +1,8 @@
+# Acceptance Test Ideas
+
+- Opening the app for the first time should redirect to `/onboarding`. Completing onboarding returns to `/today` and subsequent launches skip onboarding.
+- Switch among Today → Insights → Plan → Settings and confirm that drilling into nested routes preserves state when returning to a tab.
+- On Android, pressing the system back button pops the current tab stack; when at the root, the app should minimize instead of switching tabs.
+- Attempting to open a pro-only route without entitlement should redirect to `/paywall` and, after upgrading, resume the original route.
+- Deep link `nudge://habit/123` should display Habit Detail; malformed IDs fall back to Today with a toast.
+- After simulating process death, relaunch should restore the last selected tab and its route where possible.

--- a/test/deep_link_handler_test.dart
+++ b/test/deep_link_handler_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ai_habit_tracker/routing/deep_link_handler.dart';
+import 'package:ai_habit_tracker/shared/models/nav_intents.dart';
+
+void main() {
+  test('parses habit deep link', () {
+    final intent = DeepLinkHandler.parse(Uri.parse('nudge://habit/42'));
+    expect(intent, isA<OpenHabitIntent>());
+    expect((intent as OpenHabitIntent).habitId, '42');
+  });
+
+  test('falls back on invalid deep link', () {
+    final intent = DeepLinkHandler.parse(Uri.parse('nudge://unknown'));
+    expect(intent, isA<UnknownIntent>());
+  });
+
+  test('parses paywall deep link with next', () {
+    final intent = DeepLinkHandler.parse(Uri.parse('nudge://paywall?next=%2Ftoday'));
+    expect(intent, isA<OpenPaywallIntent>());
+    expect((intent as OpenPaywallIntent).nextLocation, '/today');
+  });
+}

--- a/test/habit_new_screen_test.dart
+++ b/test/habit_new_screen_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:ai_habit_tracker/features/habit/habit_new_screen.dart';
+import 'package:ai_habit_tracker/shared/services/nav_state_store.dart';
+
+class TestNavStateStore extends NavStateStore {
+  int draftWrites = 0;
+  bool draftCleared = false;
+
+  @override
+  Future<void> writeHabitNewDraft(String json) async {
+    draftWrites++;
+    await super.writeHabitNewDraft(json);
+  }
+
+  @override
+  Future<void> clearHabitNewDraft() async {
+    draftCleared = true;
+    await super.clearHabitNewDraft();
+  }
+}
+
+void main() {
+  testWidgets('clearing the habit draft skips autosave on dispose', (tester) async {
+    final store = TestNavStateStore();
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const HabitNewScreen(),
+          routes: [
+            GoRoute(
+              path: 'habit/:id',
+              builder: (context, state) {
+                final id = state.pathParameters['id'] ?? 'unknown';
+                return Scaffold(
+                  appBar: AppBar(title: Text('Habit $id')),
+                  body: Center(child: Text('Habit detail for $id')),
+                );
+              },
+            ),
+          ],
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          navStateStoreProvider.overrideWithValue(store),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'Morning Run');
+
+    await tester.tap(find.text('Create Habit'));
+    await tester.pumpAndSettle();
+
+    expect(store.draftCleared, isTrue);
+    expect(store.draftWrites, 0);
+    expect(await store.readHabitNewDraft(), isNull);
+  });
+}

--- a/test/route_guards_test.dart
+++ b/test/route_guards_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ai_habit_tracker/routing/route_guards.dart';
+import 'package:ai_habit_tracker/shared/services/entitlements_service.dart';
+import 'package:ai_habit_tracker/shared/services/onboarding_service.dart';
+
+void main() {
+  group('onboardingRedirect', () {
+    test('redirects to onboarding when incomplete', () async {
+      final service = OnboardingService();
+      expect(
+        await onboardingRedirect(
+          onboardingService: service,
+          attemptedLocation: '/today',
+        ),
+        '/onboarding?next=%2Ftoday',
+      );
+    });
+
+    test('allows navigation when already complete', () async {
+      final service = OnboardingService();
+      await service.completeOnboarding();
+      expect(
+        await onboardingRedirect(
+          onboardingService: service,
+          attemptedLocation: '/today',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('proRedirect', () {
+    test('redirects to paywall when user is not pro', () async {
+      final service = EntitlementsService();
+      expect(
+        await proRedirect(
+          entitlementsService: service,
+          attemptedLocation: '/habit/123/edit',
+        ),
+        '/paywall?next=%2Fhabit%2F123%2Fedit',
+      );
+    });
+
+    test('allows navigation for pro users', () async {
+      final service = EntitlementsService();
+      await service.grantPro();
+      expect(
+        await proRedirect(
+          entitlementsService: service,
+          attemptedLocation: '/habit/123/edit',
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,31 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:ai_habit_tracker/main.dart';
+import 'package:ai_habit_tracker/routing/app_router.dart';
+import 'package:ai_habit_tracker/shared/services/nav_state_store.dart';
+import 'package:ai_habit_tracker/routing/route_paths.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('renders onboarding for new users', (tester) async {
+    final navStore = NavStateStore();
+    final initialConfig = InitialNavConfiguration(
+      selectedTab: AppTab.today,
+      tabLocations: {},
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          navStateStoreProvider.overrideWithValue(navStore),
+          initialNavConfigProvider.overrideWithValue(initialConfig),
+        ],
+        child: const NudgeApp(),
+      ),
+    );
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Welcome to Nudge'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add go_router-based navigation shell with tab state persistence and telemetry hooks
- implement feature screens, services, and route guards for onboarding and pro gating
- support deep links, notification intents, and navigation state restoration stubs

## Testing
- flutter analyze
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d430892d7883219a47200ce1d785b3