### PR TITLE
Update architecture guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,15 +19,9 @@ instructions apply to the entire project unless superseded by a more specific
   appended to the root-level changelog.
 
 ## Architectural Requirements
-- Follow **Model-View-Intent (MVI)** architecture. Each feature view must have
-  an `IntentViewModel` and a `DisplayViewModel`.
-- Process all user inputs as **Intents** handled by dedicated
-  `IntentHandler` objects. `DisplayViewModel`s subscribe to the appropriate
-  `EventBus`, updating state through reducers and mutations.
 - Design all code according to:
   - [SOLID principles](https://www.geeksforgeeks.org/system-design/solid-principle-in-programming-understand-with-real-life-examples/).
   - [Clean Architecture](https://www.geeksforgeeks.org/system-design/complete-guide-to-clean-architecture/).
-  - [Composable Architecture](https://www.pointfree.co/collections/composable-architecture).
 - Adhere to the [Dart style guidelines](https://dart.dev/effective-dart/style).
 
 ## Quality Gates for Pull Requests


### PR DESCRIPTION
## Summary
- remove the repository requirement to use MVI intent handlers
- drop the mandate for composable architecture while keeping SOLID and Clean Architecture guidance

## Testing
- flutter analyze
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d43d61daec83218b4d7d277c0e650a