### PR TITLE
Add Android UI integration tests with screenshots

### DIFF
--- a/.github/workflows/android-ui-tests.yml
+++ b/.github/workflows/android-ui-tests.yml
@@ -34,8 +34,7 @@ jobs:
             flutter pub get
             flutter drive \
               --driver=integration_test/driver.dart \
-              --target=integration_test/app_test.dart \
-              -d emulator-5554
+              --target=integration_test/app_test.dart
 
       - name: Upload screenshots
         if: always()

--- a/.github/workflows/android-ui-tests.yml
+++ b/.github/workflows/android-ui-tests.yml
@@ -1,0 +1,46 @@
+name: Android UI Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  android-integration-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Fetch Flutter dependencies
+        run: flutter pub get
+
+      - name: Start emulator and run integration tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          script: |
+            flutter config --no-analytics
+            flutter pub get
+            flutter drive \
+              --driver=integration_test/driver.dart \
+              --target=integration_test/app_test.dart \
+              -d emulator-5554
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-ui-test-screenshots
+          path: build/integration_test_screenshots
+          if-no-files-found: warn

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,0 +1,23 @@
+import 'package:ai_habit_tracker/main.dart' as app;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await binding.convertFlutterSurfaceToImage();
+  });
+
+  testWidgets('displays the Today tab by default and captures a screenshot',
+      (WidgetTester tester) async {
+    await app.main();
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.today), findsOneWidget);
+    expect(find.text('Today'), findsWidgets);
+
+    await binding.takeScreenshot('home-screen');
+  });
+}

--- a/integration_test/driver.dart
+++ b/integration_test/driver.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:integration_test/integration_test_driver_extended.dart';
+
+Future<void> main() {
+  return integrationDriver(
+    onScreenshot: (
+      String screenshotName,
+      List<int> screenshotBytes, [
+      Map<String, Object?>? args,
+    ]) async {
+      final directory = Directory('build/integration_test_screenshots');
+      if (!directory.existsSync()) {
+        directory.createSync(recursive: true);
+      }
+      final file = File('${directory.path}/$screenshotName.png');
+      await file.writeAsBytes(screenshotBytes);
+      return true;
+    },
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is


### PR DESCRIPTION
## Summary
- add an integration test that exercises the default home tab and captures a baseline screenshot
- create an integration-test driver that stores captured screenshots under build/integration_test_screenshots
- configure a GitHub Actions workflow to run the integration test on an Android emulator and upload screenshots as artifacts

## Testing
- flutter analyze
- flutter test


------
https://chatgpt.com/codex/tasks/task_e_68d43ebc8f588321a97e976977833078