### PR TITLE
Add onboarding wizard flow

### DIFF
--- a/lib/features/onboarding/README-onboarding.md
+++ b/lib/features/onboarding/README-onboarding.md
@@ -1,0 +1,45 @@
+# Onboarding Wizard Integration Guide
+
+This wizard is exposed at `/onboarding` and is guarded by `OnboardingService`. The
+screen orchestrates a Riverpod `OnboardingController` that maintains state, performs
+step validation, and persists progress via `OnboardingStorage`.
+
+## Wiring the Guard
+
+1. Ensure `OnboardingService.isComplete` is checked from your global `GoRouter`
+   redirect (already wired in `app_router.dart`).
+2. The route supports an optional `next` query parameter. When provided, completion
+   will redirect to that absolute path instead of the default `/today`.
+
+## Persistence Hooks
+
+- `OnboardingStorage` currently uses an in-memory key-value implementation. Replace
+  `InMemoryKeyValueStore` with a platform store (e.g. `SharedPreferences`) by
+  providing a different implementation via the `onboardingStorageProvider` override.
+- State is serialised to JSON after every mutation to keep resume behaviour robust.
+
+## Permission Prompts
+
+- The notification and health steps call `_showPermissionPrompt`, which is a UI
+  stub that simulates the OS sheet. Replace these handlers with real integrations
+  (e.g. `FirebaseMessaging`, `HealthKit`) and pipe the resulting boolean into
+  `setNotificationsResult` and `setHealthResult` respectively.
+- When permissions are denied the controller still allows progress and emits
+  telemetry so the Settings screen can surface follow-up CTAs.
+
+## Analytics
+
+Telemetry events are sent through `TelemetryService` (stub). Replace that provider
+with your analytics stack to receive the following events:
+
+- `onboarding_step_viewed` – payload includes `step` name.
+- `onboarding_template_selected` – template toggles.
+- `onboarding_windows_saved` – emitted for target and window edits.
+- `permission_request` – `type` and `result` (granted/denied).
+- `onboarding_completed` – includes `count` of selected habits.
+
+## Testing
+
+Widget tests cover core flows (see `test/features/onboarding`). When adding
+features ensure new behaviour is represented either with widget tests or
+controller unit tests.

--- a/lib/features/onboarding/onboarding_controller.dart
+++ b/lib/features/onboarding/onboarding_controller.dart
@@ -1,0 +1,267 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../shared/models/habit_template.dart';
+import '../../shared/services/onboarding_service.dart';
+import '../../shared/services/telemetry_service.dart';
+import 'onboarding_state.dart';
+import 'onboarding_storage.dart';
+
+final onboardingStorageProvider = Provider<OnboardingStorage>((ref) {
+  return OnboardingStorage();
+});
+
+final onboardingControllerProvider =
+    StateNotifierProvider<OnboardingController, OnboardingState>((ref) {
+  final storage = ref.watch(onboardingStorageProvider);
+  final service = ref.watch(onboardingServiceProvider);
+  final telemetry = ref.watch(telemetryServiceProvider);
+  return OnboardingController(
+    storage: storage,
+    onboardingService: service,
+    telemetry: telemetry,
+  );
+});
+
+/// Ordered onboarding steps.
+const _stepsWithHealth = [
+  OnboardingStepId.welcome,
+  OnboardingStepId.templates,
+  OnboardingStepId.windows,
+  OnboardingStepId.review,
+  OnboardingStepId.notifications,
+  OnboardingStepId.health,
+  OnboardingStepId.done,
+];
+
+const _stepsWithoutHealth = [
+  OnboardingStepId.welcome,
+  OnboardingStepId.templates,
+  OnboardingStepId.windows,
+  OnboardingStepId.review,
+  OnboardingStepId.notifications,
+  OnboardingStepId.done,
+];
+
+enum OnboardingStepId {
+  welcome,
+  templates,
+  windows,
+  review,
+  notifications,
+  health,
+  done,
+}
+
+class OnboardingController extends StateNotifier<OnboardingState> {
+  OnboardingController({
+    required OnboardingStorage storage,
+    required OnboardingService onboardingService,
+    required TelemetryService telemetry,
+  })  : _storage = storage,
+        _onboardingService = onboardingService,
+        _telemetry = telemetry,
+        super(OnboardingState.initial());
+
+  final OnboardingStorage _storage;
+  final OnboardingService _onboardingService;
+  final TelemetryService _telemetry;
+
+  List<OnboardingStepId> get activeSteps =>
+      state.shouldRequestHealth ? _stepsWithHealth : _stepsWithoutHealth;
+
+  OnboardingStepId get currentStep => activeSteps[state.stepIndex];
+
+  bool get isLastStep => state.stepIndex >= activeSteps.length - 1;
+
+  bool get hasReachedTemplateLimit => state.selectedHabits.length >= 3;
+
+  OnboardingState _withClampedIndex(OnboardingState state) {
+    final steps = state.shouldRequestHealth ? _stepsWithHealth : _stepsWithoutHealth;
+    final maxIndex = steps.length - 1;
+    final clamped = state.stepIndex.clamp(0, maxIndex);
+    if (clamped != state.stepIndex) {
+      state = state.copyWith(stepIndex: clamped);
+    }
+    return state;
+  }
+
+  Future<void> hydrate({String? nextRoute, bool shouldRequestHealth = true}) async {
+    final restored = await _storage.restore();
+    if (restored != null) {
+      var nextState = restored.copyWith(
+        nextRoute: nextRoute ?? restored.nextRoute,
+        shouldRequestHealth: restored.shouldRequestHealth && shouldRequestHealth,
+      );
+      nextState = _withClampedIndex(nextState);
+      state = nextState;
+    } else {
+      var nextState = OnboardingState.initial(
+        nextRoute: nextRoute,
+        shouldRequestHealth: shouldRequestHealth,
+      );
+      nextState = _withClampedIndex(nextState);
+      state = nextState;
+      await _persist();
+    }
+  }
+
+  void updateNextRoute(String? nextRoute) {
+    state = state.copyWith(nextRoute: nextRoute);
+    unawaited(_persist());
+  }
+
+  void recordStepViewed(OnboardingStepId step) {
+    _telemetry.logEvent('onboarding_step_viewed', {'step': step.name});
+  }
+
+  void toggleTemplate(HabitTemplate template) {
+    final existingIndex = state.selectedHabits.indexWhere(
+      (habit) => habit.templateId == template.id,
+    );
+    if (existingIndex >= 0) {
+      final updated = [...state.selectedHabits]..removeAt(existingIndex);
+      state = state.copyWith(selectedHabits: updated, templatesSkipped: updated.isEmpty ? state.templatesSkipped : false);
+      _telemetry.logEvent('onboarding_template_selected', {
+        'templateId': template.id,
+        'selected': false,
+      });
+    } else {
+      if (state.selectedHabits.length >= 3) {
+        return;
+      }
+      final updated = [...state.selectedHabits, SelectedHabit.fromTemplate(template)];
+      state = state.copyWith(selectedHabits: updated, templatesSkipped: false);
+      _telemetry.logEvent('onboarding_template_selected', {
+        'templateId': template.id,
+        'selected': true,
+      });
+    }
+    unawaited(_persist());
+  }
+
+  void skipTemplates() {
+    state = state.copyWith(
+      selectedHabits: const [],
+      templatesSkipped: true,
+    );
+    unawaited(_persist());
+  }
+
+  void goToStep(OnboardingStepId step) {
+    final index = activeSteps.indexOf(step);
+    if (index == -1) {
+      return;
+    }
+    state = state.copyWith(stepIndex: index);
+    unawaited(_persist());
+  }
+
+  void updateHabitTarget(String templateId, int target) {
+    final updated = state.selectedHabits.map((habit) {
+      if (habit.templateId == templateId) {
+        return habit.copyWith(target: target.clamp(1, 1000));
+      }
+      return habit;
+    }).toList();
+    state = state.copyWith(selectedHabits: updated);
+    _telemetry.logEvent('onboarding_windows_saved', {
+      'type': 'target_update',
+      'templateId': templateId,
+      'target': target,
+    });
+    unawaited(_persist());
+  }
+
+  void updateHabitWindows(String templateId, List<TimeWindowSelection> windows) {
+    final updated = state.selectedHabits.map((habit) {
+      if (habit.templateId == templateId) {
+        return habit.copyWith(windows: windows);
+      }
+      return habit;
+    }).toList();
+    state = state.copyWith(selectedHabits: updated);
+    _telemetry.logEvent('onboarding_windows_saved', {
+      'type': 'window_update',
+      'templateId': templateId,
+      'windows': windows.map((window) => window.toJson()).toList(),
+    });
+    unawaited(_persist());
+  }
+
+  void setQuietHours(String templateId, QuietHours quietHours) {
+    final updated = state.selectedHabits.map((habit) {
+      if (habit.templateId == templateId) {
+        return habit.copyWith(quietHours: quietHours);
+      }
+      return habit;
+    }).toList();
+    state = state.copyWith(selectedHabits: updated);
+    unawaited(_persist());
+  }
+
+  void setNotificationsResult(bool granted) {
+    state = state.copyWith(notificationsGranted: granted);
+    _telemetry.logEvent('permission_request', {
+      'type': 'notifications',
+      'result': granted ? 'granted' : 'denied',
+    });
+    unawaited(_persist());
+  }
+
+  void setHealthResult(bool granted) {
+    state = state.copyWith(healthGranted: granted);
+    _telemetry.logEvent('permission_request', {
+      'type': 'health',
+      'result': granted ? 'granted' : 'denied',
+    });
+    unawaited(_persist());
+  }
+
+  void advanceStep() {
+    final nextIndex = (state.stepIndex + 1).clamp(0, activeSteps.length - 1);
+    state = _withClampedIndex(state.copyWith(stepIndex: nextIndex));
+    unawaited(_persist());
+  }
+
+  void retreatStep() {
+    final previousIndex = (state.stepIndex - 1).clamp(0, activeSteps.length - 1);
+    state = _withClampedIndex(state.copyWith(stepIndex: previousIndex));
+    unawaited(_persist());
+  }
+
+  bool validateStep(OnboardingStepId step) {
+    switch (step) {
+      case OnboardingStepId.welcome:
+        return true;
+      case OnboardingStepId.templates:
+        return state.canProceedFromTemplates;
+      case OnboardingStepId.windows:
+        return state.canProceedFromWindows;
+      case OnboardingStepId.review:
+        return state.canProceedFromWindows;
+      case OnboardingStepId.notifications:
+        return state.notificationsGranted != null;
+      case OnboardingStepId.health:
+        return !state.shouldRequestHealth || state.healthGranted != null;
+      case OnboardingStepId.done:
+        return state.isComplete;
+    }
+  }
+
+  Future<void> completeOnboarding() async {
+    state = state.copyWith(isComplete: true);
+    _telemetry.logEvent('onboarding_completed', {
+      'count': state.selectedHabits.length,
+    });
+    await _persist();
+    await _onboardingService.completeOnboarding();
+    await _storage.clear();
+  }
+
+  Future<void> _persist() async {
+    await _storage.save(state);
+  }
+}

--- a/lib/features/onboarding/onboarding_controller.dart
+++ b/lib/features/onboarding/onboarding_controller.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../shared/models/habit_template.dart';

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -3,38 +3,327 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../routing/route_paths.dart';
-import '../../shared/services/onboarding_service.dart';
+import '../../shared/models/habit_template.dart';
+import '../../shared/utils/validation.dart';
+import 'onboarding_controller.dart';
+import 'onboarding_state.dart';
+import 'steps/step_done.dart';
+import 'steps/step_permissions_health.dart';
+import 'steps/step_permissions_notifications.dart';
+import 'steps/step_review.dart';
+import 'steps/step_templates.dart';
+import 'steps/step_welcome.dart';
+import 'steps/step_windows.dart';
 
-class OnboardingScreen extends ConsumerWidget {
+class OnboardingScreen extends ConsumerStatefulWidget {
   const OnboardingScreen({super.key, this.next});
 
   final String? next;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Welcome to Nudge')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const Text(
-              'Onboarding flow placeholder. Complete to continue.',
-            ),
-            const Spacer(),
-            ElevatedButton(
-              onPressed: () async {
-                await ref.read(onboardingServiceProvider).completeOnboarding();
-                final destination = next ?? RoutePaths.today;
-                if (!context.mounted) return;
-                context.go(destination);
-              },
-              child: const Text('Finish Onboarding'),
-            ),
-          ],
+  ConsumerState<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
+  bool _hydrated = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _hydrate();
+    });
+  }
+
+  Future<void> _hydrate() async {
+    final controller = ref.read(onboardingControllerProvider.notifier);
+    await controller.hydrate(nextRoute: widget.next);
+    setState(() {
+      _hydrated = true;
+    });
+    controller.recordStepViewed(controller.currentStep);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<OnboardingState>(
+      onboardingControllerProvider,
+      (previous, next) {
+        if (previous?.stepIndex != next.stepIndex || previous == null) {
+          final controller = ref.read(onboardingControllerProvider.notifier);
+          controller.recordStepViewed(controller.currentStep);
+        }
+      },
+    );
+
+    final state = ref.watch(onboardingControllerProvider);
+    final controller = ref.read(onboardingControllerProvider.notifier);
+    final totalSteps = controller.activeSteps.length;
+    final stepIndex = state.stepIndex;
+    final currentStep = controller.currentStep;
+
+    if (!_hydrated) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return WillPopScope(
+      onWillPop: () => _handleWillPop(controller),
+      child: Scaffold(
+        appBar: AppBar(
+          leading: IconButton(
+            icon: Icon(stepIndex == 0 ? Icons.close : Icons.arrow_back),
+            onPressed: () async {
+              if (stepIndex == 0) {
+                final exit = await _confirmExit(context);
+                if (exit && context.mounted) {
+                  context.go(RoutePaths.today);
+                }
+              } else {
+                controller.retreatStep();
+              }
+            },
+          ),
+          title: const Text('Getting started'),
+        ),
+        body: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 300),
+          child: _buildStep(
+            context,
+            state,
+            controller,
+            currentStep,
+            stepIndex,
+            totalSteps,
+          ),
         ),
       ),
+    );
+  }
+
+  Future<bool> _handleWillPop(OnboardingController controller) async {
+    if (controller.state.stepIndex == 0) {
+      return await _confirmExit(context);
+    }
+    controller.retreatStep();
+    return false;
+  }
+
+  Future<bool> _confirmExit(BuildContext context) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Leave onboarding?'),
+          content: const Text('You can always resume from Settings later.'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Stay'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('Exit'),
+            ),
+          ],
+        );
+      },
+    );
+    return result ?? false;
+  }
+
+  Widget _buildStep(
+    BuildContext context,
+    OnboardingState state,
+    OnboardingController controller,
+    OnboardingStepId step,
+    int stepIndex,
+    int totalSteps,
+  ) {
+    switch (step) {
+      case OnboardingStepId.welcome:
+        return WelcomeStep(
+          key: const ValueKey('welcome'),
+          stepIndex: stepIndex,
+          totalSteps: totalSteps,
+          onGetStarted: controller.advanceStep,
+          onMaybeLater: () {
+            controller.skipTemplates();
+            controller.goToStep(OnboardingStepId.notifications);
+          },
+        );
+      case OnboardingStepId.templates:
+        return TemplatePickerStep(
+          key: const ValueKey('templates'),
+          stepIndex: stepIndex,
+          totalSteps: totalSteps,
+          templates: defaultHabitTemplates,
+          selectedHabits: state.selectedHabits,
+          onToggle: controller.toggleTemplate,
+          onContinue: () {
+            if (!controller.validateStep(OnboardingStepId.templates)) {
+              _showError(context, templateSelectionError(state.selectedHabits.length));
+              return;
+            }
+            controller.advanceStep();
+          },
+          onBack: controller.retreatStep,
+          onSkip: () {
+            controller.skipTemplates();
+            controller.advanceStep();
+          },
+        );
+      case OnboardingStepId.windows:
+        return TimeWindowsStep(
+          key: const ValueKey('windows'),
+          stepIndex: stepIndex,
+          totalSteps: totalSteps,
+          habits: state.selectedHabits,
+          onBack: controller.retreatStep,
+          onContinue: () {
+            if (!controller.validateStep(OnboardingStepId.windows)) {
+              _showError(context, windowsValidationError(state.selectedHabits));
+              return;
+            }
+            controller.advanceStep();
+          },
+          onUpdateWindows: controller.updateHabitWindows,
+          onAddCustomTime: (dialogContext) => _pickTime(dialogContext),
+        );
+      case OnboardingStepId.review:
+        return ReviewStep(
+          key: const ValueKey('review'),
+          stepIndex: stepIndex,
+          totalSteps: totalSteps,
+          habits: state.selectedHabits,
+          onBack: controller.retreatStep,
+          onConfirm: () {
+            if (!controller.validateStep(OnboardingStepId.review)) {
+              _showError(context, windowsValidationError(state.selectedHabits));
+              return;
+            }
+            controller.advanceStep();
+          },
+          onUpdateTarget: controller.updateHabitTarget,
+          onUpdateWindows: controller.updateHabitWindows,
+        );
+      case OnboardingStepId.notifications:
+        return NotificationsPermissionStep(
+          key: const ValueKey('notifications'),
+          stepIndex: stepIndex,
+          totalSteps: totalSteps,
+          status: state.notificationsGranted,
+          onBack: controller.retreatStep,
+          onContinue: () {
+            if (!controller.validateStep(OnboardingStepId.notifications)) {
+              _showError(context, 'Choose enable or skip to continue.');
+              return;
+            }
+            controller.advanceStep();
+          },
+          onEnable: () async {
+            final granted = await _showPermissionPrompt(
+              context,
+              title: 'Allow notifications?',
+              message: 'We\'ll only send relevant nudges and you can adjust at any time.',
+              confirmLabel: 'Allow',
+            );
+            if (granted != null) {
+              controller.setNotificationsResult(granted);
+            }
+          },
+          onSkip: () {
+            controller.setNotificationsResult(false);
+            controller.advanceStep();
+            _showError(context, 'Notifications can be enabled later from Settings.');
+          },
+        );
+      case OnboardingStepId.health:
+        return HealthPermissionStep(
+          key: const ValueKey('health'),
+          stepIndex: stepIndex,
+          totalSteps: totalSteps,
+          status: state.healthGranted,
+          onBack: controller.retreatStep,
+          onContinue: () {
+            if (!controller.validateStep(OnboardingStepId.health)) {
+              _showError(context, 'Choose enable or skip to continue.');
+              return;
+            }
+            controller.advanceStep();
+          },
+          onEnable: () async {
+            final granted = await _showPermissionPrompt(
+              context,
+              title: 'Connect Health?',
+              message:
+                  'Read-only access lets us mark workouts, steps, mindfulness, and sleep as done automatically.',
+              confirmLabel: 'Connect',
+            );
+            if (granted != null) {
+              controller.setHealthResult(granted);
+            }
+          },
+          onSkip: () {
+            controller.setHealthResult(false);
+            controller.advanceStep();
+          },
+        );
+      case OnboardingStepId.done:
+        return DoneStep(
+          key: const ValueKey('done'),
+          stepIndex: stepIndex,
+          totalSteps: totalSteps,
+          onFinish: () async {
+            await controller.completeOnboarding();
+            if (!mounted) return;
+            final destination = state.nextRoute ?? RoutePaths.today;
+            context.go(destination);
+          },
+        );
+    }
+  }
+
+  Future<TimeOfDay?> _pickTime(BuildContext context) {
+    final now = TimeOfDay.now();
+    return showTimePicker(
+      context: context,
+      initialTime: TimeOfDay(hour: now.hour, minute: (now.minute ~/ 5) * 5),
+    );
+  }
+
+  Future<bool?> _showPermissionPrompt(
+    BuildContext context, {
+    required String title,
+    required String message,
+    required String confirmLabel,
+  }) async {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(title),
+          content: Text(message),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Not now'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: Text(confirmLabel),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _showError(BuildContext context, String? message) {
+    if (message == null) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
     );
   }
 }

--- a/lib/features/onboarding/onboarding_state.dart
+++ b/lib/features/onboarding/onboarding_state.dart
@@ -1,0 +1,126 @@
+import 'dart:convert';
+
+import 'package:equatable/equatable.dart';
+
+import '../../shared/models/habit_template.dart';
+
+/// Immutable state describing onboarding progress.
+class OnboardingState extends Equatable {
+  const OnboardingState({
+    required this.stepIndex,
+    required this.selectedHabits,
+    required this.notificationsGranted,
+    required this.healthGranted,
+    required this.nextRoute,
+    required this.isComplete,
+    required this.shouldRequestHealth,
+    required this.templatesSkipped,
+  });
+
+  factory OnboardingState.initial({
+    String? nextRoute,
+    bool shouldRequestHealth = true,
+  }) {
+    return OnboardingState(
+      stepIndex: 0,
+      selectedHabits: const [],
+      notificationsGranted: null,
+      healthGranted: null,
+      nextRoute: nextRoute,
+      isComplete: false,
+      shouldRequestHealth: shouldRequestHealth,
+      templatesSkipped: false,
+    );
+  }
+
+  factory OnboardingState.fromJson(Map<String, dynamic> json) {
+    return OnboardingState(
+      stepIndex: json['stepIndex'] as int,
+      selectedHabits: (json['selectedHabits'] as List<dynamic>)
+          .map((raw) => SelectedHabit.fromJson(raw as Map<String, dynamic>))
+          .toList(),
+      notificationsGranted: json['notificationsGranted'] as bool?,
+      healthGranted: json['healthGranted'] as bool?,
+      nextRoute: json['nextRoute'] as String?,
+      isComplete: json['isComplete'] as bool? ?? false,
+      shouldRequestHealth: json['shouldRequestHealth'] as bool? ?? true,
+      templatesSkipped: json['templatesSkipped'] as bool? ?? false,
+    );
+  }
+
+  OnboardingState copyWith({
+    int? stepIndex,
+    List<SelectedHabit>? selectedHabits,
+    bool? notificationsGranted,
+    bool? healthGranted,
+    String? nextRoute,
+    bool? isComplete,
+    bool? shouldRequestHealth,
+    bool? templatesSkipped,
+  }) {
+    return OnboardingState(
+      stepIndex: stepIndex ?? this.stepIndex,
+      selectedHabits: selectedHabits ?? this.selectedHabits,
+      notificationsGranted: notificationsGranted ?? this.notificationsGranted,
+      healthGranted: healthGranted ?? this.healthGranted,
+      nextRoute: nextRoute ?? this.nextRoute,
+      isComplete: isComplete ?? this.isComplete,
+      shouldRequestHealth: shouldRequestHealth ?? this.shouldRequestHealth,
+      templatesSkipped: templatesSkipped ?? this.templatesSkipped,
+    );
+  }
+
+  final int stepIndex;
+  final List<SelectedHabit> selectedHabits;
+  final bool? notificationsGranted;
+  final bool? healthGranted;
+  final String? nextRoute;
+  final bool isComplete;
+  final bool shouldRequestHealth;
+  final bool templatesSkipped;
+
+  bool get hasSelectedTemplates => selectedHabits.isNotEmpty;
+
+  bool get canProceedFromTemplates => selectedHabits.length <= 3;
+
+  bool get canProceedFromWindows {
+    if (selectedHabits.isEmpty) {
+      return true;
+    }
+    return selectedHabits.every((habit) => habit.windows.isNotEmpty);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'stepIndex': stepIndex,
+      'selectedHabits': selectedHabits.map((habit) => habit.toJson()).toList(),
+      'notificationsGranted': notificationsGranted,
+      'healthGranted': healthGranted,
+      'nextRoute': nextRoute,
+      'isComplete': isComplete,
+      'shouldRequestHealth': shouldRequestHealth,
+      'templatesSkipped': templatesSkipped,
+    };
+  }
+
+  String toJsonString() => jsonEncode(toJson());
+
+  static OnboardingState? tryDecode(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return null;
+    }
+    return OnboardingState.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+  }
+
+  @override
+  List<Object?> get props => [
+        stepIndex,
+        selectedHabits,
+        notificationsGranted,
+        healthGranted,
+        nextRoute,
+        isComplete,
+        shouldRequestHealth,
+        templatesSkipped,
+      ];
+}

--- a/lib/features/onboarding/onboarding_storage.dart
+++ b/lib/features/onboarding/onboarding_storage.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'onboarding_state.dart';
+
+/// Simple key-value storage abstraction for persisting onboarding progress.
+class OnboardingStorage {
+  OnboardingStorage({KeyValueStore? store}) : _store = store ?? InMemoryKeyValueStore();
+
+  static const _storageKey = 'onboarding_state_v1';
+
+  final KeyValueStore _store;
+
+  Future<void> save(OnboardingState state) async {
+    await _store.write(_storageKey, state.toJsonString());
+  }
+
+  Future<OnboardingState?> restore() async {
+    final raw = await _store.read(_storageKey);
+    return OnboardingState.tryDecode(raw);
+  }
+
+  Future<void> clear() async {
+    await _store.delete(_storageKey);
+  }
+}
+
+/// Minimal key-value store contract allowing swapping implementations later.
+abstract class KeyValueStore {
+  Future<void> write(String key, String value);
+
+  Future<String?> read(String key);
+
+  Future<void> delete(String key);
+}
+
+/// In-memory fallback implementation used for unit testing and local dev.
+class InMemoryKeyValueStore implements KeyValueStore {
+  final Map<String, String> _storage = {};
+
+  @override
+  Future<void> delete(String key) async {
+    _storage.remove(key);
+  }
+
+  @override
+  Future<String?> read(String key) async {
+    return _storage[key];
+  }
+
+  @override
+  Future<void> write(String key, String value) async {
+    _storage[key] = value;
+  }
+}

--- a/lib/features/onboarding/steps/step_done.dart
+++ b/lib/features/onboarding/steps/step_done.dart
@@ -26,7 +26,7 @@ class DoneStep extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: const [
-          Icon(Icons.verified_rounded, size: 72, color: Colors.green),
+          const Icon(Icons.verified_rounded, size: 72, color: Colors.green),
           SizedBox(height: 16),
           Text(
             'Your plan is ready. We\'ll take you to Today to start acting on it.',

--- a/lib/features/onboarding/steps/step_done.dart
+++ b/lib/features/onboarding/steps/step_done.dart
@@ -20,17 +20,19 @@ class DoneStep extends StatelessWidget {
       stepIndex: stepIndex,
       totalSteps: totalSteps,
       title: 'All set!',
+      onPrimaryPressed: onFinish,
+      primaryLabel: 'Let\'s go',
+      onBack: null,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: const [
           Icon(Icons.verified_rounded, size: 72, color: Colors.green),
           SizedBox(height: 16),
-          Text('Your plan is ready. We\'ll take you to Today to start acting on it.'),
+          Text(
+            'Your plan is ready. We\'ll take you to Today to start acting on it.',
+          ),
         ],
       ),
-      onPrimaryPressed: onFinish,
-      primaryLabel: 'Let\'s go',
-      onBack: null,
     );
   }
 }

--- a/lib/features/onboarding/steps/step_done.dart
+++ b/lib/features/onboarding/steps/step_done.dart
@@ -27,7 +27,7 @@ class DoneStep extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Icon(Icons.verified_rounded, size: 72, color: Colors.green),
-          SizedBox(height: 16),
+          const SizedBox(height: 16),
           Text(
             'Your plan is ready. We\'ll take you to Today to start acting on it.',
           ),

--- a/lib/features/onboarding/steps/step_done.dart
+++ b/lib/features/onboarding/steps/step_done.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/widgets/step_scaffold.dart';
+
+class DoneStep extends StatelessWidget {
+  const DoneStep({
+    super.key,
+    required this.stepIndex,
+    required this.totalSteps,
+    required this.onFinish,
+  });
+
+  final int stepIndex;
+  final int totalSteps;
+  final VoidCallback onFinish;
+
+  @override
+  Widget build(BuildContext context) {
+    return StepScaffold(
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      title: 'All set!',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: const [
+          Icon(Icons.verified_rounded, size: 72, color: Colors.green),
+          SizedBox(height: 16),
+          Text('Your plan is ready. We\'ll take you to Today to start acting on it.'),
+        ],
+      ),
+      onPrimaryPressed: onFinish,
+      primaryLabel: 'Let\'s go',
+      onBack: null,
+    );
+  }
+}

--- a/lib/features/onboarding/steps/step_done.dart
+++ b/lib/features/onboarding/steps/step_done.dart
@@ -25,7 +25,7 @@ class DoneStep extends StatelessWidget {
       onBack: null,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: const [
+        children: [
           const Icon(Icons.verified_rounded, size: 72, color: Colors.green),
           SizedBox(height: 16),
           Text(

--- a/lib/features/onboarding/steps/step_permissions_health.dart
+++ b/lib/features/onboarding/steps/step_permissions_health.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/widgets/step_scaffold.dart';
+
+class HealthPermissionStep extends StatelessWidget {
+  const HealthPermissionStep({
+    super.key,
+    required this.stepIndex,
+    required this.totalSteps,
+    required this.status,
+    required this.onBack,
+    required this.onContinue,
+    required this.onEnable,
+    required this.onSkip,
+  });
+
+  final int stepIndex;
+  final int totalSteps;
+  final bool? status;
+  final VoidCallback onBack;
+  final VoidCallback onContinue;
+  final Future<void> Function() onEnable;
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return StepScaffold(
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      title: 'Connect your health data (optional)',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Import mindful minutes, steps, and workouts to auto-complete habits. We only request read-only access.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          FilledButton.icon(
+            onPressed: onEnable,
+            icon: const Icon(Icons.favorite_outline),
+            label: const Text('Enable health sync'),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            status == null
+                ? 'Status: not requested yet'
+                : status == true
+                    ? 'Health access granted ✅'
+                    : 'Health access declined. You can reconnect later.',
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+      ),
+      onPrimaryPressed: onContinue,
+      primaryLabel: 'Continue',
+      onBack: onBack,
+      secondaryLabel: 'Back',
+      tertiaryLabel: 'Skip for now',
+      onTertiaryPressed: onSkip,
+      isPrimaryEnabled: status != null,
+    );
+  }
+}

--- a/lib/features/onboarding/steps/step_permissions_health.dart
+++ b/lib/features/onboarding/steps/step_permissions_health.dart
@@ -29,6 +29,13 @@ class HealthPermissionStep extends StatelessWidget {
       stepIndex: stepIndex,
       totalSteps: totalSteps,
       title: 'Connect your health data (optional)',
+      onPrimaryPressed: onContinue,
+      primaryLabel: 'Continue',
+      onBack: onBack,
+      secondaryLabel: 'Back',
+      tertiaryLabel: 'Skip for now',
+      onTertiaryPressed: onSkip,
+      isPrimaryEnabled: status != null,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -47,19 +54,12 @@ class HealthPermissionStep extends StatelessWidget {
             status == null
                 ? 'Status: not requested yet'
                 : status == true
-                    ? 'Health access granted ✅'
-                    : 'Health access declined. You can reconnect later.',
+                ? 'Health access granted ✅'
+                : 'Health access declined. You can reconnect later.',
             style: theme.textTheme.bodySmall,
           ),
         ],
       ),
-      onPrimaryPressed: onContinue,
-      primaryLabel: 'Continue',
-      onBack: onBack,
-      secondaryLabel: 'Back',
-      tertiaryLabel: 'Skip for now',
-      onTertiaryPressed: onSkip,
-      isPrimaryEnabled: status != null,
     );
   }
 }

--- a/lib/features/onboarding/steps/step_permissions_notifications.dart
+++ b/lib/features/onboarding/steps/step_permissions_notifications.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/widgets/step_scaffold.dart';
+
+class NotificationsPermissionStep extends StatelessWidget {
+  const NotificationsPermissionStep({
+    super.key,
+    required this.stepIndex,
+    required this.totalSteps,
+    required this.status,
+    required this.onBack,
+    required this.onContinue,
+    required this.onEnable,
+    required this.onSkip,
+  });
+
+  final int stepIndex;
+  final int totalSteps;
+  final bool? status;
+  final VoidCallback onBack;
+  final VoidCallback onContinue;
+  final Future<void> Function() onEnable;
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return StepScaffold(
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      title: 'Stay accountable with gentle reminders',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Enable notifications so we can nudge you at the right time. You\'re always in control and can change this later in Settings.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          FilledButton.icon(
+            onPressed: onEnable,
+            icon: const Icon(Icons.notifications_active_outlined),
+            label: const Text('Enable notifications'),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            status == null
+                ? 'Status: not requested yet'
+                : status == true
+                    ? 'Notifications granted ✅'
+                    : 'Notifications denied. You can enable them later.',
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+      ),
+      onPrimaryPressed: onContinue,
+      primaryLabel: 'Continue',
+      onBack: onBack,
+      secondaryLabel: 'Back',
+      tertiaryLabel: 'Fix later',
+      onTertiaryPressed: onSkip,
+      isPrimaryEnabled: status != null,
+    );
+  }
+}

--- a/lib/features/onboarding/steps/step_permissions_notifications.dart
+++ b/lib/features/onboarding/steps/step_permissions_notifications.dart
@@ -29,6 +29,13 @@ class NotificationsPermissionStep extends StatelessWidget {
       stepIndex: stepIndex,
       totalSteps: totalSteps,
       title: 'Stay accountable with gentle reminders',
+      onPrimaryPressed: onContinue,
+      primaryLabel: 'Continue',
+      onBack: onBack,
+      secondaryLabel: 'Back',
+      tertiaryLabel: 'Fix later',
+      onTertiaryPressed: onSkip,
+      isPrimaryEnabled: status != null,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -47,19 +54,12 @@ class NotificationsPermissionStep extends StatelessWidget {
             status == null
                 ? 'Status: not requested yet'
                 : status == true
-                    ? 'Notifications granted ✅'
-                    : 'Notifications denied. You can enable them later.',
+                ? 'Notifications granted ✅'
+                : 'Notifications denied. You can enable them later.',
             style: theme.textTheme.bodySmall,
           ),
         ],
       ),
-      onPrimaryPressed: onContinue,
-      primaryLabel: 'Continue',
-      onBack: onBack,
-      secondaryLabel: 'Back',
-      tertiaryLabel: 'Fix later',
-      onTertiaryPressed: onSkip,
-      isPrimaryEnabled: status != null,
     );
   }
 }

--- a/lib/features/onboarding/steps/step_review.dart
+++ b/lib/features/onboarding/steps/step_review.dart
@@ -23,7 +23,8 @@ class ReviewStep extends StatelessWidget {
   final VoidCallback onBack;
   final VoidCallback onConfirm;
   final void Function(String templateId, int target) onUpdateTarget;
-  final void Function(String templateId, List<TimeWindowSelection> windows) onUpdateWindows;
+  final void Function(String templateId, List<TimeWindowSelection> windows)
+  onUpdateWindows;
 
   @override
   Widget build(BuildContext context) {
@@ -32,81 +33,106 @@ class ReviewStep extends StatelessWidget {
       stepIndex: stepIndex,
       totalSteps: totalSteps,
       title: 'Review your plan',
-      child: habits.isEmpty
-          ? const Text('No starter habits selected. You\'re good to go!')
-          : Column(
-              children: [
-                for (final habit in habits)
-                  Card(
-                    margin: const EdgeInsets.only(bottom: 12),
-                    child: Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(habit.name, style: Theme.of(context).textTheme.titleMedium),
-                          const SizedBox(height: 12),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text('Daily target (${habit.unit.label})'),
-                              TargetStepper(
-                                value: habit.target,
-                                onChanged: (value) => onUpdateTarget(habit.templateId, value),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 12),
-                          Wrap(
-                            spacing: 8,
-                            children: [
-                              for (final preset in TimeWindowPreset.values)
-                                FilterChip(
-                                  label: Text(_presetLabel(preset)),
-                                  selected: habit.windows.any(
-                                    (window) => window.isPreset && window.preset == preset,
-                                  ),
-                                  onSelected: (selected) {
-                                    final updated = [...habit.windows];
-                                    updated.removeWhere(
-                                      (window) => window.isPreset && window.preset == preset,
-                                    );
-                                    if (selected) {
-                                      updated.add(TimeWindowSelection.preset(preset));
-                                    }
-                                    onUpdateWindows(habit.templateId, updated);
-                                  },
-                                ),
-                            ],
-                          ),
-                          if (habit.windows.any((window) => window.isCustom)) ...[
-                            const SizedBox(height: 8),
-                            Wrap(
-                              spacing: 8,
-                              children: [
-                                for (final window in habit.windows.where((window) => window.isCustom))
-                                  InputChip(
-                                    label: Text(window.displayLabel),
-                                    onDeleted: () {
-                                      final updated = [...habit.windows]..remove(window);
-                                      onUpdateWindows(habit.templateId, updated);
-                                    },
-                                  ),
-                              ],
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
-                  ),
-              ],
-            ),
       onPrimaryPressed: onConfirm,
       primaryLabel: 'Looks good',
       onBack: onBack,
       secondaryLabel: 'Edit again',
       isPrimaryEnabled: helper == null,
       helperText: helper,
+      child:
+          habits.isEmpty
+              ? const Text('No starter habits selected. You\'re good to go!')
+              : Column(
+                children: [
+                  for (final habit in habits)
+                    Card(
+                      margin: const EdgeInsets.only(bottom: 12),
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              habit.name,
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            const SizedBox(height: 12),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                Text('Daily target (${habit.unit.label})'),
+                                TargetStepper(
+                                  value: habit.target,
+                                  onChanged:
+                                      (value) => onUpdateTarget(
+                                        habit.templateId,
+                                        value,
+                                      ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 12),
+                            Wrap(
+                              spacing: 8,
+                              children: [
+                                for (final preset in TimeWindowPreset.values)
+                                  FilterChip(
+                                    label: Text(_presetLabel(preset)),
+                                    selected: habit.windows.any(
+                                      (window) =>
+                                          window.isPreset &&
+                                          window.preset == preset,
+                                    ),
+                                    onSelected: (selected) {
+                                      final updated = [...habit.windows];
+                                      updated.removeWhere(
+                                        (window) =>
+                                            window.isPreset &&
+                                            window.preset == preset,
+                                      );
+                                      if (selected) {
+                                        updated.add(
+                                          TimeWindowSelection.preset(preset),
+                                        );
+                                      }
+                                      onUpdateWindows(
+                                        habit.templateId,
+                                        updated,
+                                      );
+                                    },
+                                  ),
+                              ],
+                            ),
+                            if (habit.windows.any(
+                              (window) => window.isCustom,
+                            )) ...[
+                              const SizedBox(height: 8),
+                              Wrap(
+                                spacing: 8,
+                                children: [
+                                  for (final window in habit.windows.where(
+                                    (window) => window.isCustom,
+                                  ))
+                                    InputChip(
+                                      label: Text(window.displayLabel),
+                                      onDeleted: () {
+                                        final updated = [...habit.windows]
+                                          ..remove(window);
+                                        onUpdateWindows(
+                                          habit.templateId,
+                                          updated,
+                                        );
+                                      },
+                                    ),
+                                ],
+                              ),
+                            ],
+                          ],
+                        ),
+                      ),
+                    ),
+                ],
+              ),
     );
   }
 }

--- a/lib/features/onboarding/steps/step_review.dart
+++ b/lib/features/onboarding/steps/step_review.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/models/habit_template.dart';
+import '../../../shared/utils/validation.dart';
+import '../../../shared/widgets/step_scaffold.dart';
+import '../../../shared/widgets/target_stepper.dart';
+
+class ReviewStep extends StatelessWidget {
+  const ReviewStep({
+    super.key,
+    required this.stepIndex,
+    required this.totalSteps,
+    required this.habits,
+    required this.onBack,
+    required this.onConfirm,
+    required this.onUpdateTarget,
+    required this.onUpdateWindows,
+  });
+
+  final int stepIndex;
+  final int totalSteps;
+  final List<SelectedHabit> habits;
+  final VoidCallback onBack;
+  final VoidCallback onConfirm;
+  final void Function(String templateId, int target) onUpdateTarget;
+  final void Function(String templateId, List<TimeWindowSelection> windows) onUpdateWindows;
+
+  @override
+  Widget build(BuildContext context) {
+    final helper = windowsValidationError(habits);
+    return StepScaffold(
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      title: 'Review your plan',
+      child: habits.isEmpty
+          ? const Text('No starter habits selected. You\'re good to go!')
+          : Column(
+              children: [
+                for (final habit in habits)
+                  Card(
+                    margin: const EdgeInsets.only(bottom: 12),
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(habit.name, style: Theme.of(context).textTheme.titleMedium),
+                          const SizedBox(height: 12),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text('Daily target (${habit.unit.label})'),
+                              TargetStepper(
+                                value: habit.target,
+                                onChanged: (value) => onUpdateTarget(habit.templateId, value),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 12),
+                          Wrap(
+                            spacing: 8,
+                            children: [
+                              for (final preset in TimeWindowPreset.values)
+                                FilterChip(
+                                  label: Text(_presetLabel(preset)),
+                                  selected: habit.windows.any(
+                                    (window) => window.isPreset && window.preset == preset,
+                                  ),
+                                  onSelected: (selected) {
+                                    final updated = [...habit.windows];
+                                    updated.removeWhere(
+                                      (window) => window.isPreset && window.preset == preset,
+                                    );
+                                    if (selected) {
+                                      updated.add(TimeWindowSelection.preset(preset));
+                                    }
+                                    onUpdateWindows(habit.templateId, updated);
+                                  },
+                                ),
+                            ],
+                          ),
+                          if (habit.windows.any((window) => window.isCustom)) ...[
+                            const SizedBox(height: 8),
+                            Wrap(
+                              spacing: 8,
+                              children: [
+                                for (final window in habit.windows.where((window) => window.isCustom))
+                                  InputChip(
+                                    label: Text(window.displayLabel),
+                                    onDeleted: () {
+                                      final updated = [...habit.windows]..remove(window);
+                                      onUpdateWindows(habit.templateId, updated);
+                                    },
+                                  ),
+                              ],
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+      onPrimaryPressed: onConfirm,
+      primaryLabel: 'Looks good',
+      onBack: onBack,
+      secondaryLabel: 'Edit again',
+      isPrimaryEnabled: helper == null,
+      helperText: helper,
+    );
+  }
+}
+
+String _presetLabel(TimeWindowPreset preset) {
+  switch (preset) {
+    case TimeWindowPreset.morning:
+      return 'Morning';
+    case TimeWindowPreset.afternoon:
+      return 'Afternoon';
+    case TimeWindowPreset.evening:
+      return 'Evening';
+  }
+}

--- a/lib/features/onboarding/steps/step_templates.dart
+++ b/lib/features/onboarding/steps/step_templates.dart
@@ -34,6 +34,14 @@ class TemplatePickerStep extends StatelessWidget {
       stepIndex: stepIndex,
       totalSteps: totalSteps,
       title: 'Pick a few habits to jump-start',
+      onPrimaryPressed: onContinue,
+      primaryLabel: 'Continue',
+      onBack: onBack,
+      secondaryLabel: 'Back',
+      tertiaryLabel: 'Skip templates',
+      onTertiaryPressed: onSkip,
+      isPrimaryEnabled: selectedIds.length <= maxTemplateSelection,
+      helperText: error,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -68,10 +76,11 @@ class TemplatePickerStep extends StatelessWidget {
                             const SizedBox(height: 8),
                             Text(
                               'Target: ${template.defaultTarget} ${template.unit.label}',
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .bodySmall
-                                  ?.copyWith(color: Theme.of(context).colorScheme.primary),
+                              style: Theme.of(
+                                context,
+                              ).textTheme.bodySmall?.copyWith(
+                                color: Theme.of(context).colorScheme.primary,
+                              ),
                             ),
                           ],
                         ),
@@ -88,14 +97,6 @@ class TemplatePickerStep extends StatelessWidget {
           }),
         ],
       ),
-      onPrimaryPressed: onContinue,
-      primaryLabel: 'Continue',
-      onBack: onBack,
-      secondaryLabel: 'Back',
-      tertiaryLabel: 'Skip templates',
-      onTertiaryPressed: onSkip,
-      isPrimaryEnabled: selectedIds.length <= maxTemplateSelection,
-      helperText: error,
     );
   }
 }

--- a/lib/features/onboarding/steps/step_templates.dart
+++ b/lib/features/onboarding/steps/step_templates.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/models/habit_template.dart';
+import '../../../shared/utils/validation.dart';
+import '../../../shared/widgets/step_scaffold.dart';
+
+class TemplatePickerStep extends StatelessWidget {
+  const TemplatePickerStep({
+    super.key,
+    required this.stepIndex,
+    required this.totalSteps,
+    required this.templates,
+    required this.selectedHabits,
+    required this.onToggle,
+    required this.onContinue,
+    required this.onBack,
+    required this.onSkip,
+  });
+
+  final int stepIndex;
+  final int totalSteps;
+  final List<HabitTemplate> templates;
+  final List<SelectedHabit> selectedHabits;
+  final void Function(HabitTemplate template) onToggle;
+  final VoidCallback onContinue;
+  final VoidCallback onBack;
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedIds = selectedHabits.map((habit) => habit.templateId).toSet();
+    final error = templateSelectionError(selectedIds.length);
+    return StepScaffold(
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      title: 'Pick a few habits to jump-start',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Choose up to three. You can always add more later.'),
+          const SizedBox(height: 16),
+          ...templates.map((template) {
+            final isSelected = selectedIds.contains(template.id);
+            return Card(
+              margin: const EdgeInsets.only(bottom: 12),
+              child: InkWell(
+                onTap: () => onToggle(template),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        template.emoji,
+                        style: const TextStyle(fontSize: 28),
+                      ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              template.name,
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            const SizedBox(height: 4),
+                            Text(template.description),
+                            const SizedBox(height: 8),
+                            Text(
+                              'Target: ${template.defaultTarget} ${template.unit.label}',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall
+                                  ?.copyWith(color: Theme.of(context).colorScheme.primary),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Checkbox(
+                        value: isSelected,
+                        onChanged: (_) => onToggle(template),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          }),
+        ],
+      ),
+      onPrimaryPressed: onContinue,
+      primaryLabel: 'Continue',
+      onBack: onBack,
+      secondaryLabel: 'Back',
+      tertiaryLabel: 'Skip templates',
+      onTertiaryPressed: onSkip,
+      isPrimaryEnabled: selectedIds.length <= maxTemplateSelection,
+      helperText: error,
+    );
+  }
+}

--- a/lib/features/onboarding/steps/step_welcome.dart
+++ b/lib/features/onboarding/steps/step_welcome.dart
@@ -22,6 +22,11 @@ class WelcomeStep extends StatelessWidget {
       stepIndex: stepIndex,
       totalSteps: totalSteps,
       title: 'Stay on track with gentle nudges',
+      onPrimaryPressed: onGetStarted,
+      primaryLabel: 'Get started',
+      onBack: null,
+      tertiaryLabel: 'Maybe later',
+      onTertiaryPressed: onMaybeLater,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: const [
@@ -29,14 +34,11 @@ class WelcomeStep extends StatelessWidget {
             'Nudge helps you build meaningful routines with privacy-first reminders and insights that respect your pace.',
           ),
           SizedBox(height: 16),
-          Text('We\'ll start with a couple of quick questions to tailor your plan.'),
+          Text(
+            'We\'ll start with a couple of quick questions to tailor your plan.',
+          ),
         ],
       ),
-      onPrimaryPressed: onGetStarted,
-      primaryLabel: 'Get started',
-      onBack: null,
-      tertiaryLabel: 'Maybe later',
-      onTertiaryPressed: onMaybeLater,
     );
   }
 }

--- a/lib/features/onboarding/steps/step_welcome.dart
+++ b/lib/features/onboarding/steps/step_welcome.dart
@@ -29,12 +29,12 @@ class WelcomeStep extends StatelessWidget {
       onTertiaryPressed: onMaybeLater,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: const [
-          Text(
+        children: <Widget>[
+          const Text(
             'Nudge helps you build meaningful routines with privacy-first reminders and insights that respect your pace.',
           ),
-          SizedBox(height: 16),
-          Text(
+          const SizedBox(height: 16),
+          const Text(
             'We\'ll start with a couple of quick questions to tailor your plan.',
           ),
         ],

--- a/lib/features/onboarding/steps/step_welcome.dart
+++ b/lib/features/onboarding/steps/step_welcome.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/widgets/step_scaffold.dart';
+
+class WelcomeStep extends StatelessWidget {
+  const WelcomeStep({
+    super.key,
+    required this.stepIndex,
+    required this.totalSteps,
+    required this.onGetStarted,
+    required this.onMaybeLater,
+  });
+
+  final int stepIndex;
+  final int totalSteps;
+  final VoidCallback onGetStarted;
+  final VoidCallback onMaybeLater;
+
+  @override
+  Widget build(BuildContext context) {
+    return StepScaffold(
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      title: 'Stay on track with gentle nudges',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: const [
+          Text(
+            'Nudge helps you build meaningful routines with privacy-first reminders and insights that respect your pace.',
+          ),
+          SizedBox(height: 16),
+          Text('We\'ll start with a couple of quick questions to tailor your plan.'),
+        ],
+      ),
+      onPrimaryPressed: onGetStarted,
+      primaryLabel: 'Get started',
+      onBack: null,
+      tertiaryLabel: 'Maybe later',
+      onTertiaryPressed: onMaybeLater,
+    );
+  }
+}

--- a/lib/features/onboarding/steps/step_windows.dart
+++ b/lib/features/onboarding/steps/step_windows.dart
@@ -21,7 +21,8 @@ class TimeWindowsStep extends StatelessWidget {
   final List<SelectedHabit> habits;
   final VoidCallback onBack;
   final VoidCallback onContinue;
-  final void Function(String templateId, List<TimeWindowSelection> windows) onUpdateWindows;
+  final void Function(String templateId, List<TimeWindowSelection> windows)
+  onUpdateWindows;
   final Future<TimeOfDay?> Function(BuildContext context) onAddCustomTime;
 
   @override
@@ -31,25 +32,29 @@ class TimeWindowsStep extends StatelessWidget {
       stepIndex: stepIndex,
       totalSteps: totalSteps,
       title: 'When should we nudge you?',
-      child: habits.isEmpty
-          ? const Text('We\'ll skip reminders for now. You can add habits any time from Today.')
-          : Column(
-              children: habits
-                  .map(
-                    (habit) => _HabitWindowsCard(
-                      habit: habit,
-                      onUpdate: onUpdateWindows,
-                      onAddCustomTime: onAddCustomTime,
-                    ),
-                  )
-                  .toList(),
-            ),
       onPrimaryPressed: onContinue,
       primaryLabel: 'Continue',
       onBack: onBack,
       secondaryLabel: 'Back',
       isPrimaryEnabled: helper == null,
       helperText: helper,
+      child:
+          habits.isEmpty
+              ? const Text(
+                'We\'ll skip reminders for now. You can add habits any time from Today.',
+              )
+              : Column(
+                children:
+                    habits
+                        .map(
+                          (habit) => _HabitWindowsCard(
+                            habit: habit,
+                            onUpdate: onUpdateWindows,
+                            onAddCustomTime: onAddCustomTime,
+                          ),
+                        )
+                        .toList(),
+              ),
     );
   }
 }
@@ -62,7 +67,8 @@ class _HabitWindowsCard extends StatelessWidget {
   });
 
   final SelectedHabit habit;
-  final void Function(String templateId, List<TimeWindowSelection> windows) onUpdate;
+  final void Function(String templateId, List<TimeWindowSelection> windows)
+  onUpdate;
   final Future<TimeOfDay?> Function(BuildContext context) onAddCustomTime;
 
   @override
@@ -103,7 +109,10 @@ class _HabitWindowsCard extends StatelessWidget {
                   onPressed: () async {
                     final time = await onAddCustomTime(context);
                     if (time != null) {
-                      final updated = [...windows, TimeWindowSelection.custom(time)];
+                      final updated = [
+                        ...windows,
+                        TimeWindowSelection.custom(time),
+                      ];
                       onUpdate(habit.templateId, updated);
                     }
                   },

--- a/lib/features/onboarding/steps/step_windows.dart
+++ b/lib/features/onboarding/steps/step_windows.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/models/habit_template.dart';
+import '../../../shared/utils/validation.dart';
+import '../../../shared/widgets/step_scaffold.dart';
+
+class TimeWindowsStep extends StatelessWidget {
+  const TimeWindowsStep({
+    super.key,
+    required this.stepIndex,
+    required this.totalSteps,
+    required this.habits,
+    required this.onBack,
+    required this.onContinue,
+    required this.onUpdateWindows,
+    required this.onAddCustomTime,
+  });
+
+  final int stepIndex;
+  final int totalSteps;
+  final List<SelectedHabit> habits;
+  final VoidCallback onBack;
+  final VoidCallback onContinue;
+  final void Function(String templateId, List<TimeWindowSelection> windows) onUpdateWindows;
+  final Future<TimeOfDay?> Function(BuildContext context) onAddCustomTime;
+
+  @override
+  Widget build(BuildContext context) {
+    final helper = windowsValidationError(habits);
+    return StepScaffold(
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      title: 'When should we nudge you?',
+      child: habits.isEmpty
+          ? const Text('We\'ll skip reminders for now. You can add habits any time from Today.')
+          : Column(
+              children: habits
+                  .map(
+                    (habit) => _HabitWindowsCard(
+                      habit: habit,
+                      onUpdate: onUpdateWindows,
+                      onAddCustomTime: onAddCustomTime,
+                    ),
+                  )
+                  .toList(),
+            ),
+      onPrimaryPressed: onContinue,
+      primaryLabel: 'Continue',
+      onBack: onBack,
+      secondaryLabel: 'Back',
+      isPrimaryEnabled: helper == null,
+      helperText: helper,
+    );
+  }
+}
+
+class _HabitWindowsCard extends StatelessWidget {
+  const _HabitWindowsCard({
+    required this.habit,
+    required this.onUpdate,
+    required this.onAddCustomTime,
+  });
+
+  final SelectedHabit habit;
+  final void Function(String templateId, List<TimeWindowSelection> windows) onUpdate;
+  final Future<TimeOfDay?> Function(BuildContext context) onAddCustomTime;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final presetOptions = TimeWindowPreset.values;
+    final windows = habit.windows;
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(habit.name, style: theme.textTheme.titleMedium),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              children: [
+                for (final preset in presetOptions)
+                  FilterChip(
+                    label: Text(_presetLabel(preset)),
+                    selected: windows.any(
+                      (window) => window.isPreset && window.preset == preset,
+                    ),
+                    onSelected: (selected) {
+                      final updated = [...windows];
+                      updated.removeWhere(
+                        (window) => window.isPreset && window.preset == preset,
+                      );
+                      if (selected) {
+                        updated.add(TimeWindowSelection.preset(preset));
+                      }
+                      onUpdate(habit.templateId, updated);
+                    },
+                  ),
+                TextButton.icon(
+                  onPressed: () async {
+                    final time = await onAddCustomTime(context);
+                    if (time != null) {
+                      final updated = [...windows, TimeWindowSelection.custom(time)];
+                      onUpdate(habit.templateId, updated);
+                    }
+                  },
+                  icon: const Icon(Icons.schedule),
+                  label: const Text('Custom time'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              children: [
+                for (final window in windows.where((window) => window.isCustom))
+                  InputChip(
+                    label: Text(window.displayLabel),
+                    onDeleted: () {
+                      final updated = [...windows]..remove(window);
+                      onUpdate(habit.templateId, updated);
+                    },
+                  ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Quiet hours ${habit.quietHours == null ? '10:00 PM – 7:00 AM' : _quietLabel(habit.quietHours!)} (adjust later in Settings).',
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _presetLabel(TimeWindowPreset preset) {
+  switch (preset) {
+    case TimeWindowPreset.morning:
+      return 'Morning';
+    case TimeWindowPreset.afternoon:
+      return 'Afternoon';
+    case TimeWindowPreset.evening:
+      return 'Evening';
+  }
+}
+
+String _quietLabel(QuietHours hours) {
+  return '${_formatTime(hours.start)} – ${_formatTime(hours.end)}';
+}
+
+String _formatTime(TimeOfDay time) {
+  final hour = time.hourOfPeriod == 0 ? 12 : time.hourOfPeriod;
+  final minute = time.minute.toString().padLeft(2, '0');
+  final period = time.period == DayPeriod.am ? 'AM' : 'PM';
+  return '$hour:$minute $period';
+}

--- a/lib/shared/models/habit_template.dart
+++ b/lib/shared/models/habit_template.dart
@@ -286,10 +286,10 @@ final defaultHabitTemplates = <HabitTemplate>[
     description: 'Stay hydrated with a quick reminder.',
     unit: HabitUnit.milliliters,
     defaultTarget: 250,
-    defaultWindows: const [
-      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.morning),
-      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.afternoon),
-    ],
+    defaultWindows: List.unmodifiable([
+      TimeWindowSelection.preset(TimeWindowPreset.morning),
+      TimeWindowSelection.preset(TimeWindowPreset.afternoon),
+    ]),
   ),
   HabitTemplate(
     id: 'ten-minute-walk',
@@ -298,9 +298,9 @@ final defaultHabitTemplates = <HabitTemplate>[
     description: 'Stretch your legs with a brisk walk.',
     unit: HabitUnit.minutes,
     defaultTarget: 10,
-    defaultWindows: const [
-      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.afternoon),
-    ],
+    defaultWindows: List.unmodifiable([
+      TimeWindowSelection.preset(TimeWindowPreset.afternoon),
+    ]),
   ),
   HabitTemplate(
     id: 'mindfulness',
@@ -309,10 +309,10 @@ final defaultHabitTemplates = <HabitTemplate>[
     description: 'Recharge with a short mindful break.',
     unit: HabitUnit.minutes,
     defaultTarget: 5,
-    defaultWindows: const [
-      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.morning),
-      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.evening),
-    ],
+    defaultWindows: List.unmodifiable([
+      TimeWindowSelection.preset(TimeWindowPreset.morning),
+      TimeWindowSelection.preset(TimeWindowPreset.evening),
+    ]),
   ),
   HabitTemplate(
     id: 'read-pages',
@@ -321,9 +321,9 @@ final defaultHabitTemplates = <HabitTemplate>[
     description: 'Keep learning every day.',
     unit: HabitUnit.pages,
     defaultTarget: 10,
-    defaultWindows: const [
-      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.evening),
-    ],
+    defaultWindows: List.unmodifiable([
+      TimeWindowSelection.preset(TimeWindowPreset.evening),
+    ]),
   ),
   HabitTemplate(
     id: 'stretch',
@@ -332,8 +332,8 @@ final defaultHabitTemplates = <HabitTemplate>[
     description: 'Release tension with quick stretches.',
     unit: HabitUnit.minutes,
     defaultTarget: 3,
-    defaultWindows: const [
-      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.morning),
-    ],
+    defaultWindows: List.unmodifiable([
+      TimeWindowSelection.preset(TimeWindowPreset.morning),
+    ]),
   ),
 ];

--- a/lib/shared/models/habit_template.dart
+++ b/lib/shared/models/habit_template.dart
@@ -1,0 +1,339 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+
+/// Units supported for habit targets.
+enum HabitUnit {
+  boolean,
+  count,
+  minutes,
+  milliliters,
+  pages,
+}
+
+extension HabitUnitDisplay on HabitUnit {
+  String get label {
+    switch (this) {
+      case HabitUnit.boolean:
+        return 'times';
+      case HabitUnit.count:
+        return 'count';
+      case HabitUnit.minutes:
+        return 'minutes';
+      case HabitUnit.milliliters:
+        return 'ml';
+      case HabitUnit.pages:
+        return 'pages';
+    }
+  }
+
+  String get analyticsValue {
+    return name;
+  }
+}
+
+/// Standard time windows offered to the user.
+enum TimeWindowPreset {
+  morning,
+  afternoon,
+  evening,
+}
+
+/// Represents a selected time window. Either a preset or a custom time of day.
+class TimeWindowSelection extends Equatable {
+  const TimeWindowSelection._({
+    required this.type,
+    this.preset,
+    this.customTime,
+  });
+
+  factory TimeWindowSelection.preset(TimeWindowPreset preset) {
+    return TimeWindowSelection._(
+      type: TimeWindowType.preset,
+      preset: preset,
+    );
+  }
+
+  factory TimeWindowSelection.custom(TimeOfDay customTime) {
+    return TimeWindowSelection._(
+      type: TimeWindowType.custom,
+      customTime: customTime,
+    );
+  }
+
+  factory TimeWindowSelection.fromJson(Map<String, dynamic> json) {
+    final type = TimeWindowType.values.firstWhere(
+      (value) => value.name == json['type'],
+    );
+    switch (type) {
+      case TimeWindowType.preset:
+        return TimeWindowSelection.preset(
+          TimeWindowPreset.values.firstWhere(
+            (value) => value.name == json['preset'],
+          ),
+        );
+      case TimeWindowType.custom:
+        final time = json['time'] as String;
+        final parts = time.split(':');
+        return TimeWindowSelection.custom(
+          TimeOfDay(
+            hour: int.parse(parts[0]),
+            minute: int.parse(parts[1]),
+          ),
+        );
+    }
+  }
+
+  final TimeWindowType type;
+  final TimeWindowPreset? preset;
+  final TimeOfDay? customTime;
+
+  bool get isPreset => type == TimeWindowType.preset;
+
+  bool get isCustom => type == TimeWindowType.custom;
+
+  String get displayLabel {
+    if (isPreset) {
+      switch (preset!) {
+        case TimeWindowPreset.morning:
+          return 'Morning';
+        case TimeWindowPreset.afternoon:
+          return 'Afternoon';
+        case TimeWindowPreset.evening:
+          return 'Evening';
+      }
+    }
+    final time = customTime!;
+    final hour = time.hourOfPeriod == 0 ? 12 : time.hourOfPeriod;
+    final periodLabel = time.period == DayPeriod.am ? 'AM' : 'PM';
+    final minute = time.minute.toString().padLeft(2, '0');
+    return '$hour:$minute $periodLabel';
+  }
+
+  Map<String, dynamic> toJson() {
+    switch (type) {
+      case TimeWindowType.preset:
+        return {
+          'type': type.name,
+          'preset': preset!.name,
+        };
+      case TimeWindowType.custom:
+        return {
+          'type': type.name,
+          'time': '${customTime!.hour.toString().padLeft(2, '0')}:${customTime!.minute.toString().padLeft(2, '0')}',
+        };
+    }
+  }
+
+  @override
+  List<Object?> get props => [type, preset, customTime?.hour, customTime?.minute];
+}
+
+/// Distinguishes preset versus custom time windows.
+enum TimeWindowType { preset, custom }
+
+/// Optional quiet hours configuration.
+class QuietHours extends Equatable {
+  const QuietHours({
+    required this.start,
+    required this.end,
+  });
+
+  factory QuietHours.defaultRange() {
+    return const QuietHours(
+      start: TimeOfDay(hour: 22, minute: 0),
+      end: TimeOfDay(hour: 7, minute: 0),
+    );
+  }
+
+  factory QuietHours.fromJson(Map<String, dynamic> json) {
+    return QuietHours(
+      start: _timeFromJson(json['start'] as String),
+      end: _timeFromJson(json['end'] as String),
+    );
+  }
+
+  final TimeOfDay start;
+  final TimeOfDay end;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'start': _timeToJson(start),
+      'end': _timeToJson(end),
+    };
+  }
+
+  @override
+  List<Object?> get props => [start.hour, start.minute, end.hour, end.minute];
+}
+
+String _timeToJson(TimeOfDay time) {
+  return '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
+}
+
+TimeOfDay _timeFromJson(String raw) {
+  final parts = raw.split(':');
+  return TimeOfDay(hour: int.parse(parts[0]), minute: int.parse(parts[1]));
+}
+
+/// Template metadata surfaced in the onboarding template picker.
+class HabitTemplate extends Equatable {
+  const HabitTemplate({
+    required this.id,
+    required this.name,
+    required this.emoji,
+    required this.description,
+    required this.unit,
+    required this.defaultTarget,
+    required this.defaultWindows,
+  });
+
+  final String id;
+  final String name;
+  final String emoji;
+  final String description;
+  final HabitUnit unit;
+  final int defaultTarget;
+  final List<TimeWindowSelection> defaultWindows;
+
+  @override
+  List<Object?> get props => [id, name, emoji, unit, defaultTarget, defaultWindows];
+}
+
+/// Representation of the user's customised selection derived from a template.
+class SelectedHabit extends Equatable {
+  const SelectedHabit({
+    required this.templateId,
+    required this.name,
+    required this.unit,
+    required this.target,
+    required this.windows,
+    this.quietHours,
+  });
+
+  factory SelectedHabit.fromTemplate(HabitTemplate template) {
+    return SelectedHabit(
+      templateId: template.id,
+      name: template.name,
+      unit: template.unit,
+      target: template.defaultTarget,
+      windows: template.defaultWindows,
+      quietHours: QuietHours.defaultRange(),
+    );
+  }
+
+  factory SelectedHabit.fromJson(Map<String, dynamic> json) {
+    return SelectedHabit(
+      templateId: json['templateId'] as String,
+      name: json['name'] as String,
+      unit: HabitUnit.values.firstWhere(
+        (value) => value.name == json['unit'],
+      ),
+      target: json['target'] as int,
+      windows: (json['windows'] as List<dynamic>)
+          .map((raw) => TimeWindowSelection.fromJson(raw as Map<String, dynamic>))
+          .toList(),
+      quietHours: json['quietHours'] == null
+          ? null
+          : QuietHours.fromJson(json['quietHours'] as Map<String, dynamic>),
+    );
+  }
+
+  SelectedHabit copyWith({
+    String? name,
+    HabitUnit? unit,
+    int? target,
+    List<TimeWindowSelection>? windows,
+    QuietHours? quietHours,
+  }) {
+    return SelectedHabit(
+      templateId: templateId,
+      name: name ?? this.name,
+      unit: unit ?? this.unit,
+      target: target ?? this.target,
+      windows: windows ?? this.windows,
+      quietHours: quietHours ?? this.quietHours,
+    );
+  }
+
+  final String templateId;
+  final String name;
+  final HabitUnit unit;
+  final int target;
+  final List<TimeWindowSelection> windows;
+  final QuietHours? quietHours;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'templateId': templateId,
+      'name': name,
+      'unit': unit.name,
+      'target': target,
+      'windows': windows.map((window) => window.toJson()).toList(),
+      'quietHours': quietHours?.toJson(),
+    };
+  }
+
+  @override
+  List<Object?> get props => [templateId, name, unit, target, windows, quietHours];
+}
+
+/// A curated selection of starter templates offered during onboarding.
+final defaultHabitTemplates = <HabitTemplate>[
+  HabitTemplate(
+    id: 'drink-water',
+    name: 'Drink Water',
+    emoji: '💧',
+    description: 'Stay hydrated with a quick reminder.',
+    unit: HabitUnit.milliliters,
+    defaultTarget: 250,
+    defaultWindows: const [
+      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.morning),
+      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.afternoon),
+    ],
+  ),
+  HabitTemplate(
+    id: 'ten-minute-walk',
+    name: '10-min Walk',
+    emoji: '🚶',
+    description: 'Stretch your legs with a brisk walk.',
+    unit: HabitUnit.minutes,
+    defaultTarget: 10,
+    defaultWindows: const [
+      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.afternoon),
+    ],
+  ),
+  HabitTemplate(
+    id: 'mindfulness',
+    name: 'Mindfulness 5 min',
+    emoji: '🧘',
+    description: 'Recharge with a short mindful break.',
+    unit: HabitUnit.minutes,
+    defaultTarget: 5,
+    defaultWindows: const [
+      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.morning),
+      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.evening),
+    ],
+  ),
+  HabitTemplate(
+    id: 'read-pages',
+    name: 'Read 10 pages',
+    emoji: '📚',
+    description: 'Keep learning every day.',
+    unit: HabitUnit.pages,
+    defaultTarget: 10,
+    defaultWindows: const [
+      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.evening),
+    ],
+  ),
+  HabitTemplate(
+    id: 'stretch',
+    name: 'Stretch',
+    emoji: '🤸',
+    description: 'Release tension with quick stretches.',
+    unit: HabitUnit.minutes,
+    defaultTarget: 3,
+    defaultWindows: const [
+      TimeWindowSelection._(type: TimeWindowType.preset, preset: TimeWindowPreset.morning),
+    ],
+  ),
+];

--- a/lib/shared/services/telemetry_service.dart
+++ b/lib/shared/services/telemetry_service.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Stub telemetry service capturing analytics events.
+class TelemetryService {
+  void logEvent(String name, [Map<String, Object?> parameters = const {}]) {
+    // TODO: integrate with analytics backend.
+  }
+}
+
+final telemetryServiceProvider = Provider<TelemetryService>((ref) {
+  return TelemetryService();
+});

--- a/lib/shared/utils/validation.dart
+++ b/lib/shared/utils/validation.dart
@@ -1,0 +1,24 @@
+import '../models/habit_template.dart';
+
+const int maxTemplateSelection = 3;
+
+String? templateSelectionError(int selectionCount) {
+  if (selectionCount > maxTemplateSelection) {
+    return 'Pick up to $maxTemplateSelection habits to start.';
+  }
+  if (selectionCount == maxTemplateSelection) {
+    return 'You\'ve hit the $maxTemplateSelection habit limit. Adjust or continue.';
+  }
+  return null;
+}
+
+String? windowsValidationError(List<SelectedHabit> habits) {
+  final missing = habits.where((habit) => habit.windows.isEmpty).toList();
+  if (missing.isEmpty) {
+    return null;
+  }
+  if (missing.length == 1) {
+    return 'Add a time window for ${missing.single.name}.';
+  }
+  return 'Add at least one time window to each selected habit.';
+}

--- a/lib/shared/widgets/choice_chip_group.dart
+++ b/lib/shared/widgets/choice_chip_group.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+/// Wraps a list of [ChoiceChip]s with selection management.
+class ChoiceChipGroup<T> extends StatelessWidget {
+  const ChoiceChipGroup({
+    super.key,
+    required this.options,
+    required this.isSelected,
+    required this.onSelected,
+    this.allowMultiple = true,
+    this.spacing = 12,
+    this.runSpacing = 12,
+  });
+
+  final List<ChipOption<T>> options;
+  final bool Function(T value) isSelected;
+  final void Function(T value, bool selected) onSelected;
+  final bool allowMultiple;
+  final double spacing;
+  final double runSpacing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: spacing,
+      runSpacing: runSpacing,
+      children: [
+        for (final option in options)
+          ChoiceChip(
+            label: Text(option.label),
+            avatar: option.avatar,
+            selected: isSelected(option.value),
+            onSelected: (selected) => onSelected(option.value, selected),
+          ),
+      ],
+    );
+  }
+}
+
+class ChipOption<T> {
+  const ChipOption({
+    required this.value,
+    required this.label,
+    this.avatar,
+  });
+
+  final T value;
+  final String label;
+  final Widget? avatar;
+}

--- a/lib/shared/widgets/step_scaffold.dart
+++ b/lib/shared/widgets/step_scaffold.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+
+/// Shared layout for onboarding wizard steps.
+class StepScaffold extends StatelessWidget {
+  const StepScaffold({
+    super.key,
+    required this.stepIndex,
+    required this.totalSteps,
+    required this.title,
+    required this.child,
+    required this.onPrimaryPressed,
+    required this.primaryLabel,
+    this.onBack,
+    this.secondaryLabel,
+    this.onSecondaryPressed,
+    this.tertiaryLabel,
+    this.onTertiaryPressed,
+    this.isPrimaryEnabled = true,
+    this.helperText,
+  });
+
+  final int stepIndex;
+  final int totalSteps;
+  final String title;
+  final Widget child;
+  final VoidCallback? onPrimaryPressed;
+  final String primaryLabel;
+  final VoidCallback? onBack;
+  final String? secondaryLabel;
+  final VoidCallback? onSecondaryPressed;
+  final String? tertiaryLabel;
+  final VoidCallback? onTertiaryPressed;
+  final bool isPrimaryEnabled;
+  final String? helperText;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final progress = totalSteps == 0 ? 0.0 : (stepIndex + 1) / totalSteps;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Step ${stepIndex + 1} of $totalSteps',
+            style: theme.textTheme.labelLarge,
+          ),
+          const SizedBox(height: 8),
+          LinearProgressIndicator(value: progress),
+          const SizedBox(height: 24),
+          Text(
+            title,
+            style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: 24),
+                child: child,
+              ),
+            ),
+          ),
+          if (helperText != null) ...[
+            Text(
+              helperText!,
+              style: theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.error),
+            ),
+            const SizedBox(height: 12),
+          ],
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (tertiaryLabel != null && onTertiaryPressed != null) ...[
+                TextButton(
+                  onPressed: onTertiaryPressed,
+                  child: Text(tertiaryLabel!),
+                ),
+                const SizedBox(height: 8),
+              ],
+              Row(
+                children: [
+                  if (onBack != null)
+                    OutlinedButton(
+                      onPressed: onBack,
+                      child: Text(secondaryLabel ?? 'Back'),
+                    ),
+                  if (onBack != null) const SizedBox(width: 12),
+                  Expanded(
+                    child: FilledButton(
+                      onPressed: isPrimaryEnabled ? onPrimaryPressed : null,
+                      child: Text(primaryLabel),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/target_stepper.dart
+++ b/lib/shared/widgets/target_stepper.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+/// Simple +/- stepper to adjust numeric targets.
+class TargetStepper extends StatelessWidget {
+  const TargetStepper({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.min = 1,
+    this.max = 1000,
+  });
+
+  final int value;
+  final ValueChanged<int> onChanged;
+  final int min;
+  final int max;
+
+  void _change(int delta) {
+    final newValue = (value + delta).clamp(min, max);
+    onChanged(newValue);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.remove_circle_outline),
+          onPressed: value > min ? () => _change(-1) : null,
+        ),
+        Text(
+          '$value',
+          style: theme.textTheme.titleMedium,
+        ),
+        IconButton(
+          icon: const Icon(Icons.add_circle_outline),
+          onPressed: value < max ? () => _change(1) : null,
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/onboarding/onboarding_controller_test.dart
+++ b/test/features/onboarding/onboarding_controller_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ai_habit_tracker/features/onboarding/onboarding_controller.dart';
+import 'package:ai_habit_tracker/features/onboarding/onboarding_state.dart';
+import 'package:ai_habit_tracker/features/onboarding/onboarding_storage.dart';
+import 'package:ai_habit_tracker/shared/models/habit_template.dart';
+import 'package:ai_habit_tracker/shared/services/onboarding_service.dart';
+import 'package:ai_habit_tracker/shared/services/telemetry_service.dart';
+
+void main() {
+  late OnboardingController controller;
+  late OnboardingStorage storage;
+  late OnboardingService service;
+
+  setUp(() async {
+    storage = OnboardingStorage(store: InMemoryKeyValueStore());
+    service = OnboardingService();
+    controller = OnboardingController(
+      storage: storage,
+      onboardingService: service,
+      telemetry: TelemetryService(),
+    );
+    await controller.hydrate();
+  });
+
+  test('selecting templates toggles up to limit', () {
+    controller.toggleTemplate(defaultHabitTemplates[0]);
+    controller.toggleTemplate(defaultHabitTemplates[1]);
+    controller.toggleTemplate(defaultHabitTemplates[2]);
+
+    expect(controller.state.selectedHabits, hasLength(3));
+    expect(controller.hasReachedTemplateLimit, isTrue);
+
+    controller.toggleTemplate(defaultHabitTemplates[0]);
+    expect(controller.state.selectedHabits, hasLength(2));
+  });
+
+  test('windows validation fails when habit has no window', () {
+    controller.toggleTemplate(defaultHabitTemplates.first);
+    final habitId = controller.state.selectedHabits.first.templateId;
+    controller.updateHabitWindows(habitId, []);
+
+    expect(controller.validateStep(OnboardingStepId.windows), isFalse);
+    expect(controller.state.canProceedFromWindows, isFalse);
+  });
+
+  test('complete onboarding marks service and clears storage', () async {
+    await controller.completeOnboarding();
+
+    expect(controller.state.isComplete, isTrue);
+    expect(service.isCompleteSync, isTrue);
+    final restored = await storage.restore();
+    expect(restored, isNull);
+  });
+
+  test('hydrate restores saved state', () async {
+    controller.toggleTemplate(defaultHabitTemplates.first);
+    controller.advanceStep();
+    await controller.hydrate(nextRoute: '/today');
+
+    expect(controller.state.nextRoute, '/today');
+    expect(controller.state.stepIndex, equals(1));
+  });
+}

--- a/test/features/onboarding/onboarding_controller_test.dart
+++ b/test/features/onboarding/onboarding_controller_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:ai_habit_tracker/features/onboarding/onboarding_controller.dart';
-import 'package:ai_habit_tracker/features/onboarding/onboarding_state.dart';
 import 'package:ai_habit_tracker/features/onboarding/onboarding_storage.dart';
 import 'package:ai_habit_tracker/shared/models/habit_template.dart';
 import 'package:ai_habit_tracker/shared/services/onboarding_service.dart';

--- a/test/features/onboarding/onboarding_screen_test.dart
+++ b/test/features/onboarding/onboarding_screen_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:ai_habit_tracker/features/onboarding/onboarding_controller.dart';
+import 'package:ai_habit_tracker/features/onboarding/onboarding_screen.dart';
+import 'package:ai_habit_tracker/features/onboarding/onboarding_storage.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('OnboardingScreen', () {
+    testWidgets('first run completes and navigates to today', (tester) async {
+      final storage = OnboardingStorage(store: InMemoryKeyValueStore());
+      final router = _buildRouter('/');
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [onboardingStorageProvider.overrideWithValue(storage)],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Looks good'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Enable notifications'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Allow'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Skip for now'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text("Let's go"));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('today-screen')), findsOneWidget);
+    });
+
+    testWidgets('resume restores windows step', (tester) async {
+      final storage = OnboardingStorage(store: InMemoryKeyValueStore());
+
+      Future<void> runFlow(GoRouter router) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [onboardingStorageProvider.overrideWithValue(storage)],
+            child: MaterialApp.router(routerConfig: router),
+          ),
+        );
+        await tester.pumpAndSettle();
+      }
+
+      var router = _buildRouter('/');
+      await runFlow(router);
+
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Drink Water'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('When should we nudge you?'), findsOneWidget);
+
+      // Simulate process death by rebuilding with the same storage.
+      router = _buildRouter('/');
+      await runFlow(router);
+      await tester.pumpAndSettle();
+
+      expect(find.text('When should we nudge you?'), findsOneWidget);
+    });
+
+    testWidgets('next route parameter respected', (tester) async {
+      final storage = OnboardingStorage(store: InMemoryKeyValueStore());
+      final router = _buildRouter('/?next=%2Fhabit%2Fnew');
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [onboardingStorageProvider.overrideWithValue(storage)],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Looks good'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Enable notifications'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Allow'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Skip for now'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text("Let's go"));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('habit-new-screen')), findsOneWidget);
+    });
+  });
+}
+
+GoRouter _buildRouter(String initialLocation) {
+  return GoRouter(
+    initialLocation: initialLocation,
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) {
+          return OnboardingScreen(next: state.uri.queryParameters['next']);
+        },
+      ),
+      GoRoute(
+        path: '/today',
+        builder: (context, state) => const Placeholder(key: ValueKey('today-screen')),
+      ),
+      GoRoute(
+        path: '/habit/new',
+        builder: (context, state) => const Placeholder(key: ValueKey('habit-new-screen')),
+      ),
+    ],
+  );
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -26,6 +26,6 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    expect(find.text('Welcome to Nudge'), findsOneWidget);
+    expect(find.text('Stay on track with gentle nudges'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- implement full onboarding wizard with multi-step flow, persistence, and telemetry hooks
- add shared widgets, models, and utilities for templates, time windows, and validation
- introduce controller, storage, and tests covering controller logic and navigation flows

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d43eecd100832191d2e3e60d0f5480