### PR TITLE
Add iOS UI test automation

### DIFF
--- a/.github/workflows/ios-ui-tests.yml
+++ b/.github/workflows/ios-ui-tests.yml
@@ -26,15 +26,15 @@ jobs:
           cd ios
           pod install
 
-        - name: Run iOS UI tests
-          run: |
-            set -eo pipefail
-            xcodebuild \
-              -workspace ios/Runner.xcworkspace \
-              -scheme Runner \
-              -destination 'platform=iOS Simulator,name=iPhone 15' \
-              -resultBundlePath build/ios_ui_tests.xcresult \
-              test
+      - name: Run iOS UI tests
+        run: |
+          set -eo pipefail
+          xcodebuild \
+            -workspace ios/Runner.xcworkspace \
+            -scheme Runner \
+            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -resultBundlePath build/ios_ui_tests.xcresult \
+            test
 
       - name: Export UI test screenshots
         run: |

--- a/.github/workflows/ios-ui-tests.yml
+++ b/.github/workflows/ios-ui-tests.yml
@@ -1,0 +1,52 @@
+name: iOS UI Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ui-tests:
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.22.1'
+          channel: stable
+
+      - name: Install dependencies
+        run: |
+          flutter pub get
+          cd ios
+          pod install
+
+        - name: Run iOS UI tests
+          run: |
+            set -eo pipefail
+            xcodebuild \
+              -workspace ios/Runner.xcworkspace \
+              -scheme Runner \
+              -destination 'platform=iOS Simulator,name=iPhone 15' \
+              -resultBundlePath build/ios_ui_tests.xcresult \
+              test
+
+      - name: Export UI test screenshots
+        run: |
+          mkdir -p build/ui-test-artifacts
+          xcrun xcresulttool export \
+            --type directory \
+            --output-path build/ui-test-artifacts \
+            --xcresultpath build/ios_ui_tests.xcresult
+
+      - name: Upload UI test screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ui-test-screenshots
+          path: build/ui-test-artifacts
+          if-no-files-found: warn

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -12,18 +12,26 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
-		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
-		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+                97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
+                97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+                D6A5F4E12B5B9B4200F6E5A3 /* RunnerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A5F4E22B5B9B4200F6E5A3 /* RunnerUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		331C8085294A63A400263BE5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
-			remoteInfo = Runner;
-		};
+                331C8085294A63A400263BE5 /* PBXContainerItemProxy */ = {
+                        isa = PBXContainerItemProxy;
+                        containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+                        proxyType = 1;
+                        remoteGlobalIDString = 97C146ED1CF9000F007C117D;
+                        remoteInfo = Runner;
+                };
+                D6A5F4E92B5B9B4200F6E5A3 /* PBXContainerItemProxy */ = {
+                        isa = PBXContainerItemProxy;
+                        containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+                        proxyType = 1;
+                        remoteGlobalIDString = 97C146ED1CF9000F007C117D;
+                        remoteInfo = Runner;
+                };
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -53,8 +61,10 @@
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+                97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+                97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+                D6A5F4E22B5B9B4200F6E5A3 /* RunnerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerUITests.swift; sourceTree = "<group>"; };
+                D6A5F4E32B5B9B4200F6E5A3 /* RunnerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,25 +97,35 @@
 			name = Flutter;
 			sourceTree = "<group>";
 		};
-		97C146E51CF9000F007C117D = {
-			isa = PBXGroup;
-			children = (
-				9740EEB11CF90186004384FC /* Flutter */,
-				97C146F01CF9000F007C117D /* Runner */,
-				97C146EF1CF9000F007C117D /* Products */,
-				331C8082294A63A400263BE5 /* RunnerTests */,
-			);
-			sourceTree = "<group>";
-		};
-		97C146EF1CF9000F007C117D /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				97C146EE1CF9000F007C117D /* Runner.app */,
-				331C8081294A63A400263BE5 /* RunnerTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
+                97C146E51CF9000F007C117D = {
+                        isa = PBXGroup;
+                        children = (
+                                9740EEB11CF90186004384FC /* Flutter */,
+                                97C146F01CF9000F007C117D /* Runner */,
+                                97C146EF1CF9000F007C117D /* Products */,
+                                331C8082294A63A400263BE5 /* RunnerTests */,
+                                D6A5F4E42B5B9B4200F6E5A3 /* RunnerUITests */,
+                        );
+                        sourceTree = "<group>";
+                };
+                97C146EF1CF9000F007C117D /* Products */ = {
+                        isa = PBXGroup;
+                        children = (
+                                97C146EE1CF9000F007C117D /* Runner.app */,
+                                331C8081294A63A400263BE5 /* RunnerTests.xctest */,
+                                D6A5F4E32B5B9B4200F6E5A3 /* RunnerUITests.xctest */,
+                        );
+                        name = Products;
+                        sourceTree = "<group>";
+                };
+                D6A5F4E42B5B9B4200F6E5A3 /* RunnerUITests */ = {
+                        isa = PBXGroup;
+                        children = (
+                                D6A5F4E22B5B9B4200F6E5A3 /* RunnerUITests.swift */,
+                        );
+                        path = RunnerUITests;
+                        sourceTree = "<group>";
+                };
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
@@ -124,23 +144,40 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		331C8080294A63A400263BE5 /* RunnerTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
-			buildPhases = (
-				331C807D294A63A400263BE5 /* Sources */,
-				331C807F294A63A400263BE5 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				331C8086294A63A400263BE5 /* PBXTargetDependency */,
-			);
-			name = RunnerTests;
-			productName = RunnerTests;
-			productReference = 331C8081294A63A400263BE5 /* RunnerTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
+                331C8080294A63A400263BE5 /* RunnerTests */ = {
+                        isa = PBXNativeTarget;
+                        buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
+                        buildPhases = (
+                                331C807D294A63A400263BE5 /* Sources */,
+                                331C807F294A63A400263BE5 /* Resources */,
+                        );
+                        buildRules = (
+                        );
+                        dependencies = (
+                                331C8086294A63A400263BE5 /* PBXTargetDependency */,
+                        );
+                        name = RunnerTests;
+                        productName = RunnerTests;
+                        productReference = 331C8081294A63A400263BE5 /* RunnerTests.xctest */;
+                        productType = "com.apple.product-type.bundle.unit-test";
+                };
+                D6A5F4E72B5B9B4200F6E5A3 /* RunnerUITests */ = {
+                        isa = PBXNativeTarget;
+                        buildConfigurationList = D6A5F4EA2B5B9B4200F6E5A3 /* Build configuration list for PBXNativeTarget "RunnerUITests" */;
+                        buildPhases = (
+                                D6A5F4E52B5B9B4200F6E5A3 /* Sources */,
+                                D6A5F4E62B5B9B4200F6E5A3 /* Resources */,
+                        );
+                        buildRules = (
+                        );
+                        dependencies = (
+                                D6A5F4E82B5B9B4200F6E5A3 /* PBXTargetDependency */,
+                        );
+                        name = RunnerUITests;
+                        productName = RunnerUITests;
+                        productReference = D6A5F4E32B5B9B4200F6E5A3 /* RunnerUITests.xctest */;
+                        productType = "com.apple.product-type.bundle.ui-testing";
+                };
 		97C146ED1CF9000F007C117D /* Runner */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
@@ -170,16 +207,20 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
-				TargetAttributes = {
-					331C8080294A63A400263BE5 = {
-						CreatedOnToolsVersion = 14.0;
-						TestTargetID = 97C146ED1CF9000F007C117D;
-					};
-					97C146ED1CF9000F007C117D = {
-						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 1100;
-					};
-				};
+                                TargetAttributes = {
+                                        331C8080294A63A400263BE5 = {
+                                                CreatedOnToolsVersion = 14.0;
+                                                TestTargetID = 97C146ED1CF9000F007C117D;
+                                        };
+                                        97C146ED1CF9000F007C117D = {
+                                                CreatedOnToolsVersion = 7.3.1;
+                                                LastSwiftMigration = 1100;
+                                        };
+                                        D6A5F4E72B5B9B4200F6E5A3 = {
+                                                CreatedOnToolsVersion = 15.1;
+                                                TestTargetID = 97C146ED1CF9000F007C117D;
+                                        };
+                                };
 			};
 			buildConfigurationList = 97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */;
 			compatibilityVersion = "Xcode 9.3";
@@ -193,22 +234,30 @@
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
-			targets = (
-				97C146ED1CF9000F007C117D /* Runner */,
-				331C8080294A63A400263BE5 /* RunnerTests */,
-			);
-		};
+                        targets = (
+                                97C146ED1CF9000F007C117D /* Runner */,
+                                331C8080294A63A400263BE5 /* RunnerTests */,
+                                D6A5F4E72B5B9B4200F6E5A3 /* RunnerUITests */,
+                        );
+                };
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		331C807F294A63A400263BE5 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		97C146EC1CF9000F007C117D /* Resources */ = {
+                331C807F294A63A400263BE5 /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+                D6A5F4E62B5B9B4200F6E5A3 /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+                97C146EC1CF9000F007C117D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -256,15 +305,23 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		331C807D294A63A400263BE5 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		97C146EA1CF9000F007C117D /* Sources */ = {
+                331C807D294A63A400263BE5 /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+                D6A5F4E52B5B9B4200F6E5A3 /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                D6A5F4E12B5B9B4200F6E5A3 /* RunnerUITests.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+                97C146EA1CF9000F007C117D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -276,11 +333,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		331C8086294A63A400263BE5 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 97C146ED1CF9000F007C117D /* Runner */;
-			targetProxy = 331C8085294A63A400263BE5 /* PBXContainerItemProxy */;
-		};
+                331C8086294A63A400263BE5 /* PBXTargetDependency */ = {
+                        isa = PBXTargetDependency;
+                        target = 97C146ED1CF9000F007C117D /* Runner */;
+                        targetProxy = 331C8085294A63A400263BE5 /* PBXContainerItemProxy */;
+                };
+                D6A5F4E82B5B9B4200F6E5A3 /* PBXTargetDependency */ = {
+                        isa = PBXTargetDependency;
+                        target = 97C146ED1CF9000F007C117D /* Runner */;
+                        targetProxy = D6A5F4E92B5B9B4200F6E5A3 /* PBXContainerItemProxy */;
+                };
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -409,21 +471,71 @@
 			};
 			name = Release;
 		};
-		331C808A294A63A400263BE5 /* Profile */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.quillanq.aihabittracker.aiHabitTracker.RunnerTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
-			};
-			name = Profile;
-		};
+                331C808A294A63A400263BE5 /* Profile */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                BUNDLE_LOADER = "$(TEST_HOST)";
+                                CODE_SIGN_STYLE = Automatic;
+                                CURRENT_PROJECT_VERSION = 1;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                MARKETING_VERSION = 1.0;
+                                PRODUCT_BUNDLE_IDENTIFIER = com.quillanq.aihabittracker.aiHabitTracker.RunnerTests;
+                                PRODUCT_NAME = "$(TARGET_NAME)";
+                                SWIFT_VERSION = 5.0;
+                                TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
+                        };
+                        name = Profile;
+                };
+                D6A5F4EB2B5B9B4200F6E5A3 /* Debug */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                CODE_SIGN_STYLE = Automatic;
+                                CURRENT_PROJECT_VERSION = 1;
+                                DEVELOPMENT_TEAM = 79UZ8VBYBG;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                MARKETING_VERSION = 1.0;
+                                PRODUCT_BUNDLE_IDENTIFIER = com.quillanq.aihabittracker.aiHabitTracker.RunnerUITests;
+                                PRODUCT_NAME = "$(TARGET_NAME)";
+                                SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+                                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+                                SWIFT_VERSION = 5.0;
+                                TARGETED_DEVICE_FAMILY = "1,2";
+                                TEST_TARGET_NAME = Runner;
+                        };
+                        name = Debug;
+                };
+                D6A5F4EC2B5B9B4200F6E5A3 /* Release */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                CODE_SIGN_STYLE = Automatic;
+                                CURRENT_PROJECT_VERSION = 1;
+                                DEVELOPMENT_TEAM = 79UZ8VBYBG;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                MARKETING_VERSION = 1.0;
+                                PRODUCT_BUNDLE_IDENTIFIER = com.quillanq.aihabittracker.aiHabitTracker.RunnerUITests;
+                                PRODUCT_NAME = "$(TARGET_NAME)";
+                                SWIFT_VERSION = 5.0;
+                                TARGETED_DEVICE_FAMILY = "1,2";
+                                TEST_TARGET_NAME = Runner;
+                        };
+                        name = Release;
+                };
+                D6A5F4ED2B5B9B4200F6E5A3 /* Profile */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                CODE_SIGN_STYLE = Automatic;
+                                CURRENT_PROJECT_VERSION = 1;
+                                DEVELOPMENT_TEAM = 79UZ8VBYBG;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                MARKETING_VERSION = 1.0;
+                                PRODUCT_BUNDLE_IDENTIFIER = com.quillanq.aihabittracker.aiHabitTracker.RunnerUITests;
+                                PRODUCT_NAME = "$(TARGET_NAME)";
+                                SWIFT_VERSION = 5.0;
+                                TARGETED_DEVICE_FAMILY = "1,2";
+                                TEST_TARGET_NAME = Runner;
+                        };
+                        name = Profile;
+                };
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -583,17 +695,27 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				331C8088294A63A400263BE5 /* Debug */,
-				331C8089294A63A400263BE5 /* Release */,
-				331C808A294A63A400263BE5 /* Profile */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */ = {
+                331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */ = {
+                        isa = XCConfigurationList;
+                        buildConfigurations = (
+                                331C8088294A63A400263BE5 /* Debug */,
+                                331C8089294A63A400263BE5 /* Release */,
+                                331C808A294A63A400263BE5 /* Profile */,
+                        );
+                        defaultConfigurationIsVisible = 0;
+                        defaultConfigurationName = Release;
+                };
+                D6A5F4EA2B5B9B4200F6E5A3 /* Build configuration list for PBXNativeTarget "RunnerUITests" */ = {
+                        isa = XCConfigurationList;
+                        buildConfigurations = (
+                                D6A5F4EB2B5B9B4200F6E5A3 /* Debug */,
+                                D6A5F4EC2B5B9B4200F6E5A3 /* Release */,
+                                D6A5F4ED2B5B9B4200F6E5A3 /* Profile */,
+                        );
+                        defaultConfigurationIsVisible = 0;
+                        defaultConfigurationName = Release;
+                };
+                97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				97C147031CF9000F007C117D /* Debug */,

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,17 @@
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D6A5F4E72B5B9B4200F6E5A3"
+               BuildableName = "RunnerUITests.xctest"
+               BlueprintName = "RunnerUITests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/ios/RunnerUITests/RunnerUITests.swift
+++ b/ios/RunnerUITests/RunnerUITests.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+final class RunnerUITests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    func testLaunchAndCaptureHomeScreenshot() throws {
+        let screenshot = app.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = "01-Home"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
## Summary
- add an Xcode UI testing target that launches the app and captures a home screen screenshot
- register the new target with the Runner scheme so it runs alongside existing tests
- provision a macOS GitHub Actions workflow that runs the UI tests in a simulator and uploads screenshots as artifacts

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d45299333c83218e31495baf2d2884