### PR TITLE
Update Flutter version for iOS UI tests

### DIFF
--- a/.github/workflows/ios-ui-tests.yml
+++ b/.github/workflows/ios-ui-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.29.0'
+          flutter-version: '3.35.4'
           channel: stable
 
       - name: Install dependencies

--- a/.github/workflows/ios-ui-tests.yml
+++ b/.github/workflows/ios-ui-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.35.4'
+          flutter-version: '3.29.2'
           channel: stable
 
       - name: Install dependencies

--- a/.github/workflows/ios-ui-tests.yml
+++ b/.github/workflows/ios-ui-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.1'
+          flutter-version: '3.29.0'
           channel: stable
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- align the iOS UI test workflow with the application's Flutter toolchain by pinning Flutter 3.29.0

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68d45be6980c8321a1eb6e9be2c62f04